### PR TITLE
Update service link URL

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -4,7 +4,7 @@ host: docs.cloud.service.gov.uk
 # Header-related options
 show_govuk_logo: true
 service_name: Platform as a Service
-service_link: https://www.cloud.service.gov.uk
+service_link: https://govuk-paas.cloudapps.digital
 phase: Beta
 
 # Links to show on right-hand-side of header


### PR DESCRIPTION
Possible fix for #2 

Updated service link URL to https://govuk-paas.cloudapps.digital/ as this currently displays the Product Overview page. The previous link resulted in a 404 response.