### PR TITLE
Postgres encryption and free plan

### DIFF
--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -1,19 +1,23 @@
 # Deploy a backing service
 
-## Backing services overview
+## Services and plans
 
-
-Your application probably relies on backing services such as a database, an email delivery service or a monitoring system.
+Many 12-factor applications rely on backing services such as a database, an email delivery service or a monitoring system.
 
 In Cloud Foundry, backing services are referred to as 'services' and are available through the Cloud Foundry ``cf marketplace`` command.
 
 Currently, the only service available is the [PostgreSQL database service](/#postgresql). 
 
-### Paid services
+Each service can have multiple plans available. For example, there are different PostgreSQL plans which vary by availability, storage capacity and encryption.
 
-Some services (including ``postgres``) are considered paid services. Your organization may not have the ability to use paid services enabled. Access to paid services can either be enabled or disabled based on your [organisation quota](/#quotas).
 
-If you try to create a service and receive an error stating "service instance cannot be created because paid service plans are not allowed", please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
+### Paid service plans
+
+Some service plans are paid: that is, you can potentially be billed by us for using them. 
+
+By default, access to paid plans is not enabled for a new organisation. Whether this is enabled or not is controlled by your [organisation's quota settings](/#quotas).
+
+If you try to use a paid service and receive an error stating "service instance cannot be created because paid service plans are not allowed", please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
 
 ### Accessing services
 

--- a/source/documentation/deploying_services/postgres.md
+++ b/source/documentation/deploying_services/postgres.md
@@ -118,7 +118,7 @@ To create a service and bind it to your app:
 
 Your app must make a [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) connection to the PostgreSQL service. Most libraries use TLS by default.
 
-The Cloud Foundry buildpack will automatically parse the ``VCAP_SERVICES`` [environment variable](/#system-provided-environment-variables) to get details of the PostgreSQL service. The buildpack will set `DATABASE_URL` to the first database found.
+GOV.UK PaaS will automatically parse the ``VCAP_SERVICES`` [environment variable](/#system-provided-environment-variables) to get details of the  service and then set the `DATABASE_URL` variable to the first database found.
 
 Use ``cf env APPNAME`` to see the environment variables.
 

--- a/source/documentation/deploying_services/postgres.md
+++ b/source/documentation/deploying_services/postgres.md
@@ -49,7 +49,7 @@ You should test how your app deals with a failover to make sure you are benefiti
 
 ### Encrypted PostgreSQL plans
 
-Plans with ``enc`` in the name include encryption at rest of the database storage. This means that the data is encrypted while the service is stopped.
+Plans with ``enc`` in the name include encryption at rest of the database storage. This means that the data on the disk and in snapshots is encrypted.
 
 We recommend that you use an encrypted plan for production services or those that use real data.
 
@@ -118,9 +118,7 @@ To create a service and bind it to your app:
 
 Your app must make a [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) connection to the PostgreSQL service. Most libraries use TLS by default.
 
-Your app will need to parse the ``VCAP_SERVICES`` [environment variable](/#system-provided-environment-variables) to get details of the PostgreSQL service (or use a library that does so).
-
-(Note that for some languages/frameworks, the Cloud Foundry buildpack will automatically parse ``VCAP_SERVICES`` and set `DATABASE_URL` to the first database found.)
+The Cloud Foundry buildpack will automatically parse the ``VCAP_SERVICES`` [environment variable](/#system-provided-environment-variables) to get details of the PostgreSQL service. The buildpack will set `DATABASE_URL` to the first database found.
 
 Use ``cf env APPNAME`` to see the environment variables.
 

--- a/source/documentation/deploying_services/postgres.md
+++ b/source/documentation/deploying_services/postgres.md
@@ -51,7 +51,7 @@ You should test how your app deals with a failover to make sure you are benefiti
 
 Plans with ``enc`` in the name include encryption at rest of the database storage. This means that the data is encrypted while the service is stopped.
 
-We recommend that you use an encrypted plan for production services.
+We recommend that you use an encrypted plan for production services or those that use real data.
 
 Once you've created a service instance, you can't enable or disable encryption. There's no way to convert an unencrypted PostgreSQL service instance to an encrypted one later.
 
@@ -73,7 +73,7 @@ To create a service and bind it to your app:
 
     ``cf create-service postgres M-dedicated-9.5 my-pg-service``
 
-    Note that for production usage, we recommend you select a high-availability encrypted plan (with ``HA-enc`` in the name).
+    Note that for production usage, we recommend you select a high-availability encrypted plan (one with ``HA-enc`` in the name).
 
 3. It may take some time (5 to 10 minutes) for the service instance to be set up. To find out its status, run:
 
@@ -120,7 +120,7 @@ Your app must make a [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Securit
 
 Your app will need to parse the ``VCAP_SERVICES`` [environment variable](/#system-provided-environment-variables) to get details of the PostgreSQL service (or use a library that does so).
 
-(Note that for some languages/frameworks, the Cloud Foundry buildpack will automatically parse ``VCAP_SERVICES`` and set DATABASE_URL to the first database found.)
+(Note that for some languages/frameworks, the Cloud Foundry buildpack will automatically parse ``VCAP_SERVICES`` and set `DATABASE_URL` to the first database found.)
 
 Use ``cf env APPNAME`` to see the environment variables.
 
@@ -128,15 +128,17 @@ You can check for database connection errors by viewing the recent logs with ``c
 
 ### PostgreSQL service maintenance times
 
-The PaaS PostgreSQL service is currently provided by Amazon Web Services RDS. Each PostgreSQL service you create will have a randomly-assigned weekly 30 minute maintenance window, during which there may be brief downtime. (To minimise downtime, select the ``*-HA-dedicated-9.5`` high availability plan, where the asterisk is the size of the plan). Minor version upgrades (for example from 9.4.1 to 9.4.2) will be applied during this window.
+The PaaS PostgreSQL service is currently provided by Amazon Web Services RDS. Each PostgreSQL service you create will have a randomly-assigned weekly 30 minute maintenance window, during which there may be brief downtime. (To minimise this downtime, select a high availability plan with `HA` in its name). 
+
+Minor version upgrades (for example from 9.4.1 to 9.4.2) will be applied during the maintenance window.
 
 For more details, see the [Amazon RDS Maintenance documentation](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html) [external page].
 
-If you need to know the time of your maintenance window, please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk). Times will be from 22:00 to 06:00 UTC. We will add the ability to set the time of the maintenance window in a future version of GOV.UK PaaS.
+If you need to know the time of your maintenance window, please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk). Window start times will vary from 22:00 to 06:00 UTC. We will add the ability to set the time of the maintenance window in a future version of GOV.UK PaaS.
 
 ### PostgreSQL service backup
 
-The data stored within any PostgreSQL service you create is backed up using the standard Amazon RDS backup system.
+The data stored within any PostgreSQL service you create is backed up using the standard Amazon RDS backup system, except if you are using the free plan.
 
 Backups are taken nightly and data is retained for 7 days.
 

--- a/source/documentation/deploying_services/postgres.md
+++ b/source/documentation/deploying_services/postgres.md
@@ -4,49 +4,62 @@ GOV.UK PaaS enables you to create a PostgreSQL database service (powered by Amaz
 
 In Cloud Foundry, each service may have multiple plans available with different characteristics.
 
-Currently, GOV.UK PaaS offers a ``postgres`` service which is available with six separate plans:
+Currently, GOV.UK PaaS offers a ``postgres`` service with multiple plans available.
 
-* ``S-dedicated-9.5``
-* ``S-HA-dedicated-9.5`` (high availability, recommended for production)
-* ``M-dedicated-9.5``
-* ``M-HA-dedicated-9.5`` (high availability, recommended for production)
-* ``L-dedicated-9.5``
-* ``L-HA-dedicated-9.5`` (high availability, recommended for production)
+To see the available plans, run:
 
-The number in the plan name (in this example, ``9.5``) is the PostgreSQL version.
+```
+cf marketplace -s postgres
+```
 
-The letter at the beginning of the plan name corresponds to the instance size on Amazon Web Services as follows:
+Here is a shortened example of the sort of output you will see (the exact plans will vary):
 
-* ``S`` - ``t2.small``
-* ``M`` - ``m4.medium``
-* ``L`` - ``m4.2xlarge``
+```
+service plan             description                                                                                                                                                       free or paid
+M-dedicated-9.5          20GB Storage, Dedicated Instance, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large.                                           paid
+M-HA-dedicated-9.5       20GB Storage, Dedicated Instance, Highly Available, Max 500 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.m4.large.                         paid
+...
+Free                     5GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version 9.5. DB Instance Class: db.t2.micro.                              free
+```
 
-Full details of what these plans include is available on [the AWS Product Details page](https://aws.amazon.com/rds/details/#DB_Instance_Classes).
+You can look up the ``DB Instance Class``  to find out more detail about what these plans offer on [the AWS Product Details page](https://aws.amazon.com/rds/details/#DB_Instance_Classes).
 
-### Paid services
+### Free and paid PostgreSQL plans
 
-``postgres`` is considered a paid service. Paid services may not be enabled on your account. If you try to create a service and receive an error stating "service instance cannot be created because paid service plans are not allowed", please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
+Most PostgreSQL plans are paid, meaning that we will bill you based on your usage of the service.
 
+There is a free plan available with limited storage. This should *only* be used for development or testing, not for production.
+
+Paid services may not be enabled for your organisation. If they're not enabled, when you try to set up a paid service, you'll receive the error "service instance cannot be created because paid service plans are not allowed". One of your [Org Managers](/#org-manager) must contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) to request that we enable paid services.
+
+
+### High availability plans
+
+We recommend you use one of the high availability plans (indicated by `HA` in the name) for your production apps. These plans use Amazon RDS Multi-AZ instances which are designed to be 99.95% available (see [Amazon's SLA](https://aws.amazon.com/rds/sla/) for details).
+
+When you use the high availability plan, Amazon RDS provides a hot standby service for failover in the event that the original service fails.
+
+The failover process means that Amazon RDS will automatically change the DNS record of the database instance to point to the standby instance. You should make sure that your app doesn't cache the database IP, and any DNS caching should be configured with a low time to live (TTL). Consult the documentation for the language/framework you are using to find out how to do this.
+
+During failover, there will be an outage period (from tens of seconds to a few minutes).
+
+See the [Amazon RDS documentation on the failover process](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html#Concepts.MultiAZ.Failover) for more details.
+
+You should test how your app deals with a failover to make sure you are benefiting from the high availability plan. We can trigger a failover for you. Please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) to arrange this.
+
+### Encrypted PostgreSQL plans
+
+Plans with ``enc`` in the name include encryption at rest of the database storage. This means that the data is encrypted while the service is stopped.
+
+We recommend that you use an encrypted plan for production services.
+
+Once you've created a service instance, you can't enable or disable encryption. There's no way to convert an unencrypted PostgreSQL service instance to an encrypted one later.
 
 ### Setting up a PostgreSQL service
 
 To create a service and bind it to your app:
 
 1. From the command line, run:
-
-    ``cf marketplace``
-
-    to see the available services.
-
-    You will see output like this:
-
-    
-        service     plans                                   description
-        postgres    S-dedicated-9.5*, S-HA-dedicated-9.5*,  AWS RDS PostgreSQL service
-                    M-dedicated-9.5*, M-HA-dedicated-9.5*,
-                    L-dedicated-9.5*, L-HA-dedicated-9.5*
-
-2.  Run:
 
     ``cf marketplace -s postgres``
 
@@ -60,7 +73,7 @@ To create a service and bind it to your app:
 
     ``cf create-service postgres M-dedicated-9.5 my-pg-service``
 
-    Note that for a production service, we strongly recommend you select the high-availability plan (``M-HA-dedicated-9.5``).
+    Note that for production usage, we recommend you select a high-availability encrypted plan (with ``HA-enc`` in the name).
 
 3. It may take some time (5 to 10 minutes) for the service instance to be set up. To find out its status, run:
 
@@ -135,19 +148,7 @@ Note that data restore will not be available in the event of an RDS outage affec
 
 For more details about how the RDS backup system works, see [Amazon's DB Instance Backups documentation](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.BackingUpAndRestoringAmazonRDSInstances.html) [external page].
 
-### High availability details
 
-We recommend you use the high availability plan (``*-HA-dedicated-9.5``) for any production apps, where the asterisk is the size of the plan.
-
-When you use the high availability plan, Amazon RDS provides a hot standby service to use for failover in the event that the original service fails.
-
-The failover process means that Amazon RDS will automatically change the DNS record of the database instance to point to the standby instance. You should make sure that your app doesn't cache the database IP, and any DNS caching should be configured with a low time to live (TTL). Consult the documentation for the language/framework you are using to find out how to do this.
-
-During failover, there will be an outage period (from tens of seconds to a few minutes).
-
-See the [Amazon RDS documentation on the failover process](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html#Concepts.MultiAZ.Failover) for more details.
-
-If you wish to test how your app deals with a failover, we can trigger one for you. Please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) to arrange this.
 
 ### Read replicas
 


### PR DESCRIPTION
Story #138344907 to document free plan and #137716243 to document encrypted plan. Descriptions below

#138344907

What

Document the existence of the Postgresql "free" plan.

Why

Because without authorisation this is the only plan people trying out the PaaS can use, and it is not clear that it exists in the documentation.

If we don't do this

We will continue to receive requests from trial tenants asking for their account to be upgraded when it doesn't need to be,




#137716243

What

Add documentation to the tenant manual about the new Postgres service plans which have "enc" in their name:
database storage is encrypted as rest (when the RDS instance is shutdown)
we recommend that you use it for production workloads
you cannot enable or disable encryption on an existing service
it is not compatible with small plans
we haven't provided it for non-HA plans

Why

We added the plans in #137006863 and users should know about them.

It is done when

There is documentation explaining what it means the encryption, how to use the plans and restrictions.

If we don’t do this

Users might get confused with the new plans, and create DBs without encryption that later cannot be upgraded.