### PR TITLE
Run linkchecker over docs in Travis.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config
 /.bundle
 
+# Ignore virtualenv dir
+/.venv
+
 # Ignore the build directory
 /build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: ruby
+rvm:
+  - 2.3.3
+
+cache:
+  bundler: true
+
+before_install:
+  - pip install --user -r requirements.txt
+
+script:
+  - ./script/test

--- a/Gemfile
+++ b/Gemfile
@@ -18,4 +18,4 @@ gem 'middleman-syntax', '~> 3.0.0'
 
 gem 'redcarpet', '~> 3.3.2'
 
-gem 'table_of_contents', github: 'alphagov/table_of_contents', ref: 'f6d37fe1e837cebf7354abafd891f755148e7efa'
+gem 'table_of_contents', git: 'https://github.com/alphagov/table_of_contents', ref: 'f6d37fe1e837cebf7354abafd891f755148e7efa'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/alphagov/table_of_contents.git
+  remote: https://github.com/alphagov/table_of_contents
   revision: f6d37fe1e837cebf7354abafd891f755148e7efa
   ref: f6d37fe1e837cebf7354abafd891f755148e7efa
   specs:
@@ -160,4 +160,4 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   1.12.5
+   1.13.7

--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ You should now be able to view a live preview at http://localhost:4567.
 
 Changes to the `tech-docs.yml` file require stopping and restarting the server to show up in the preview. (Stop it with `Ctrl-C`).
 
+## Running tests
+
+This repo is configured in Travis to run a link-checker over the generated docs
+to find any broken links etc. If you want to run this locally, do the
+following:
+
+```
+virtualenv .venv
+source .venv/bin/activate
+pip install -Ur requirements.txt
+./script/test
+```
+
 ## Build and deploy
 
 The docs are hosted on the PaaS.

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -1,5 +1,5 @@
 # Host to use for canonical URL generation (without trailing slash)
-host: docs.cloud.service.gov.uk
+host: https://docs.cloud.service.gov.uk
 
 # Header-related options
 show_govuk_logo: true
@@ -11,7 +11,7 @@ phase: Beta
 header_links:
   About: https://www.cloud.service.gov.uk
   Features: https://www.cloud.service.gov.uk/features.html
-  Roadmap: hhttps://www.cloud.service.gov.uk/roadmap.html
+  Roadmap: https://www.cloud.service.gov.uk/roadmap.html
   Documentation: /
   Support: https://www.cloud.service.gov.uk/support.html
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+linkchecker==9.3
+
+# https://github.com/wummel/linkchecker/issues/649
+requests==2.9.1

--- a/script/test
+++ b/script/test
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eu
+
+ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+cd "${ROOT_DIR}"
+
+bundle exec middleman build
+
+linkchecker ./build/


### PR DESCRIPTION
## What

Add Travis integration to run the linkchecker over the generated docs.

The linkchecker found a couple of broken links, so this fixes them as well.

## How to review

Code review.
Verify Travis build passes.

## Who can review

Anyone but myself.