### PR TITLE
Clarify checking out code

### DIFF
--- a/source/documentation/deploying_apps/deploying_django.md
+++ b/source/documentation/deploying_apps/deploying_django.md
@@ -8,9 +8,9 @@ These steps assume you have already carried out the setup process explained in t
 
 If you are just getting started learning CloudFoundry, you can use the sandbox space by running: ``cf target -s sandbox``
 
-1. Check out your Django app to a local folder.
+1. Put the code for your Django app into a local directory (for example, by checking it out of version control).
 
-2. Add `*.pyc` and `local_settings.py` to your `.gitignore`, file, then 
+2. If you are using Git, add `*.pyc` and `local_settings.py` to your `.gitignore`, file, then 
    [exclude files ignored by Git](/#excluding-files) so Cloud Foundry will ignore them too.
 
 3. Tell Cloud Foundry which Python runtime to use by creating a `runtime.txt`   file in the root of the local folder. The contents of the file should  
@@ -96,7 +96,7 @@ If you are just getting started learning CloudFoundry, you can use the sandbox s
 
     ``cf push APPNAME``
 
-    from the local folder.
+    from the directory which contains all the code and configuration files.
 
     If you want to upload the app without starting it (for example, if you need to create a PostgreSQL service), run `cf push --no-start APPNAME`, then when you are ready to start the app, run `cf start APPNAME`.
 

--- a/source/documentation/deploying_apps/deploying_node_js.md
+++ b/source/documentation/deploying_apps/deploying_node_js.md
@@ -58,7 +58,9 @@ This is the code for the example app we are going to use. It is a basic web serv
 
 1. You can optionally run `npm install` to preinstall dependencies rather than having them added during the PaaS staging process.
 
-1. Run `cf push APPNAME` to upload and start the app. If you want to upload the app without starting it (for example, if you need to create a PostgreSQL service), run `cf push --no-start APPNAME`, then when you are ready to start the app, run `cf start APPNAME`.
+1. Run `cf push APPNAME` from the top level of the directory which contains all the code and configuration files. 
+
+  If you want to upload the app without starting it (for example, if you need to create a PostgreSQL service), run `cf push --no-start APPNAME`, then when you are ready to start the app, run `cf start APPNAME`.
 
 See [Tips for Node.js Applications](https://docs.cloudfoundry.org/buildpacks/node/node-tips.html) [external link] in the Cloud Foundry documentation for more information.
 

--- a/source/documentation/deploying_apps/deploying_rails.md
+++ b/source/documentation/deploying_apps/deploying_rails.md
@@ -18,7 +18,7 @@ It's also important to realise that if you deploy an app using the same name and
 
 This is how to deploy a Rails app that doesn't require a database.
 
-1. Check out your Rails app to a local folder.
+1. Put the code for your Rails app into a local directory (for example, by checking it out of version control).
 
 1. [Exclude files ignored by Git](/#excluding-files).
 
@@ -44,7 +44,7 @@ This is how to deploy a Rails app that doesn't require a database.
     cf push APPNAME
     ```
 
-    from the folder where you checked out your app.
+    from the directory which contains all the code and configuration files for your app.
 
     If you do not specify a name for the app after the ``cf push`` command, the name from the manifest file is used.
 
@@ -70,13 +70,13 @@ Note that the only database service currently supported by PaaS is PostgreSQL. I
 
  The Cloud Foundry buildpack for Ruby automatically gets the details of the first available PostgreSQL service from the ``VCAP_SERVICES`` environment variable and sets the Ruby `DATABASE_URL` environment variable accordingly. Ensure that your app is configured to use `DATABASE_URL` to set its database configuration when deployed to the PaaS.
 
-1. Check out your Rails app to a local folder.
+1. Put the code for your Rails app into a local directory (for example, by checking it out of version control).
 
-1. [Exclude files ignored by Git](/#excluding-files).
+1. If you are using Git, you may wish to [exclude files ignored by Git](/#excluding-files).
 
 1. If you're using Rails 4, [add the `rails_12factor` gem](https://github.com/heroku/rails_12factor#install) for better logging. Rails 5 has this functionality built in by default.
 
-1. Create a manifest.yml file in the folder where you checked out your app.
+1. Create a manifest.yml file in the directory where you checked out your app.
 
         ---
         applications:
@@ -97,7 +97,7 @@ Note that the only database service currently supported by PaaS is PostgreSQL. I
     cf push --no-start APPNAME
     ```
 
-    from the folder where you checked out your app.
+    from the directory which contains all the code and configuration files for your app.
 
     If you do not specify a name for the app after the ``cf push`` command, the name from the manifest file is used.
 

--- a/source/documentation/deploying_apps/deploying_static_sites.md
+++ b/source/documentation/deploying_apps/deploying_static_sites.md
@@ -43,7 +43,7 @@ These steps assume you have already carried out the setup process explained in t
 
     A buildpack provides any framework and runtime support required by an app. If your app was written in Ruby, you would use ``ruby_buildpack``. In this case, we just want to serve a static file, so we use ``staticfile_buildpack``.
 
-4. From the directory where the `manifest.yml` file is, run:
+4. From the directory where you created the files, run:
 
     ``
     cf push

--- a/source/documentation/deploying_apps/index.md
+++ b/source/documentation/deploying_apps/index.md
@@ -4,12 +4,7 @@
 
 The `cf push` command is used both to create a new app and to push a new version of an existing one. The basic steps:
 
-1. Check out whatever version of the code you want to deploy from version control.
-
-    ```
-    git checkout master
-    ```
-
+1. Put the code you want to deploy in a directory. This is usually accomplished by checking it out of version control.
 
 1. Target the appropriate organisation and space.
 
@@ -23,7 +18,7 @@ The `cf push` command is used both to create a new app and to push a new version
     cf push APPNAME
     ```
 
-    from the directory where you checked out the code.
+    from the directory which contains the code and configuration files for your app.
 
 The app should now be live at `https://APPNAME.cloudapps.digital`.
 


### PR DESCRIPTION
Rewrite to describe the goal rather than specifying using Git.
Preface specific advice about Git with "if you are using Git".
Clarify that the directory you push from should contain *all* the app
code and config files (assuming it's not worth a digression to explain
how you can configure to look in different folders).

#136104121

When I’m deploying an app to the PaaS for the first time
I need to understand how my files must be checked out of a local folder
So that I can successfully deploy to the PaaS.
Acceptance Criteria
Documentation is clear what is meant by ‘check out’. If there’s a
specific way that users must do this then we should say so.
User Research
During lab testing, a participant used SVN instead of Git to check out
the app. This meant that his manifest file was not in the same
directory as the rest of the app so his push failed. It wasn't clear to
him from the documentation what he should have done differently