### PR TITLE
Document CRLF issue

### DIFF
--- a/source/documentation/troubleshooting/line-endings.md
+++ b/source/documentation/troubleshooting/line-endings.md
@@ -1,0 +1,23 @@
+## Push failure from Windows due to CRLF
+
+Pushing an app can fail if you are pushing from a Windows machine that has saved the app files with Windows-style (CRLF) line breaks.
+
+In interpreted languages, you will get a `No such file or directory` error.
+
+This is an example of the error with Ruby:
+
+```
+2016-12-02T06:03:25.95-0800 [APP/PROC/WEB/0]ERR /usr/bin/env: ruby
+2016-12-02T06:03:25.95-0800 [APP/PROC/WEB/0]ERR : No such file or directory
+2016-12-02T06:03:25.95-0800 [APP/PROC/WEB/0]OUT Exit status 127
+```
+
+If you find that pushing an app from a Windows machine is failing like this, you must make sure that files are not being saved with CRLF line breaks. Check the settings in your text editor or IDE.
+
+If the files are from a Git repository, disable Git's `autocrlf` setting:
+
+```
+git config --global core.autocrlf false
+```
+
+then clone the repository again.

--- a/source/documentation/troubleshooting/line-endings.md
+++ b/source/documentation/troubleshooting/line-endings.md
@@ -1,8 +1,8 @@
 ## Pushing apps fails on Windows (line endings issue)
 
-We are aware of some cases where pushing an app can fail if you are pushing from a Windows machine that has saved Cloud Foundry configuration files with Windows-style (CRLF) line endings.
+We are aware of some cases where pushing an app can fail if you are pushing from a Windows machine that has saved project files with Windows-style (CRLF) line endings.
 
-This happens because some buildpacks do not interpret the CRLF line endings correctly. This is an example of an error arising from this problem when using the Ruby buildpack:
+This happens because some buildpacks do not interpret the CRLF line endings correctly. This is an example of an error arising from an executable script with CRLF line endings when using the Ruby buildpack:
 
 ```
 2016-12-02T06:03:25.95-0800 [APP/PROC/WEB/0]ERR /usr/bin/env: ruby

--- a/source/documentation/troubleshooting/line-endings.md
+++ b/source/documentation/troubleshooting/line-endings.md
@@ -1,10 +1,8 @@
-## Push failure from Windows due to CRLF
+## Pushing apps fails on Windows (line endings issue)
 
-Pushing an app can fail if you are pushing from a Windows machine that has saved the app files with Windows-style (CRLF) line breaks.
+We are aware of some cases where pushing an app can fail if you are pushing from a Windows machine that has saved Cloud Foundry configuration files with Windows-style (CRLF) line endings.
 
-In interpreted languages, you will get a `No such file or directory` error.
-
-This is an example of the error with Ruby:
+This happens because some buildpacks do not interpret the CRLF line endings correctly. This is an example of an error arising from this problem when using the Ruby buildpack:
 
 ```
 2016-12-02T06:03:25.95-0800 [APP/PROC/WEB/0]ERR /usr/bin/env: ruby
@@ -12,9 +10,9 @@ This is an example of the error with Ruby:
 2016-12-02T06:03:25.95-0800 [APP/PROC/WEB/0]OUT Exit status 127
 ```
 
-If you find that pushing an app from a Windows machine is failing like this, you must make sure that files are not being saved with CRLF line breaks. Check the settings in your text editor or IDE.
+Similar problems may happen in other buildpacks. If you find that pushing an app from Windows is failing, try making sure that files in your project are being saved with Unix-style LF line endings, not Windows-style CRLF line endings. Most text editors aimed at developers allow you to change the line ending style.
 
-If the files are from a Git repository, disable Git's `autocrlf` setting:
+If you are working with a Git repository, disable Git's `autocrlf` setting:
 
 ```
 git config --global core.autocrlf false


### PR DESCRIPTION
Explain to Windows users that pushing with CRLF line breaks can cause
errors.

Story: https://www.pivotaltracker.com/story/show/135421943

## What

Note that Cloud foundry at this time runs all applications in Linux
containers.
Add some instructions to the docs so that new Windows users know that
files with CRLF line endings won't always work

## Suggestions to consider

turn off the autocrlf setting in git
Or make sure that you specify the interpeter to be used in a command in
manifest.yml or a Procfile eg. command: ruby foo.rb

## Why

We had an issue in user research where a user tried to push our sample
ruby app from a windows machine in a git repo with autocrlf turned on.
It failed because Linux was unable to understand the shebang line.