### PR TITLE
Reorganise Jenkins doc, document rate limit

### DIFF
--- a/source/documentation/deploying_apps/jenkins.md
+++ b/source/documentation/deploying_apps/jenkins.md
@@ -7,13 +7,7 @@ There are two main approaches to pushing applications to GOV.UK PaaS with [Jenki
 
 Both approaches require you to set up the credentials plugin first.
 
-### Login rate limit
-
-For security reasons, the PaaS will lock an account if it logs in 5 times within a 5 minute period. The methods we describe below will trigger a new login every time Jenkins pushes an app. 
-
-If you have multiple Jenkins jobs, or jobs that run frequently, you should take care not to go over this rate limit by having Jenkins push 5 times from the same account within 5 minutes.
-
-We are looking into an alternative login method to avoid this limitation.
+Note that for security reasons, GOV.UK PaaS will lock your account if Jenkins makes multiple failed login attempts within a short period of time. This can happen if you provide incorrect or expired login details. See the [Failed login rate limit](#failed-login-rate-limit) section for more information.
 
 
 ### Setting up the credentials plugin

--- a/source/documentation/deploying_apps/jenkins.md
+++ b/source/documentation/deploying_apps/jenkins.md
@@ -3,15 +3,17 @@
 There are two main approaches to pushing applications to GOV.UK PaaS with [Jenkins](https://jenkins.io/):
 
 1. Use custom scripts (allows full scripting of deployments)
-1. Use the Cloud Foundry plugin for Jenkins (less flexible)
+1. Use the Cloud Foundry plugin for Jenkins (less flexible, relies on application manifest for configuration)
 
-Both of these approaches require you to add a Cloud Foundry username and password to Jenkins using the credentials plugin. To do this, follow the instructions on [Setting up the credentials plugin](#setting-up-the-credentials-plugin).
+Both approaches require you to set up the credentials plugin first.
 
+### Login rate limit
 
-Setting up custom scripts allows you to fully script your deployment. To do this securely, you will need to follow the [Setting up custom scripts](#setting-up-custom-scripts) instructions to make credentials available as environment variables.
+For security reasons, the PaaS will lock an account if it logs in 5 times within a 5 minute period. The methods we describe below will trigger a new login every time Jenkins pushes an app. 
 
-Using the Cloud Foundry plugin only allows Jenkins to push your application to GOV.UK PaaS as a post-build action: the equivalent of doing a `cf login` followed by a `cf push`. There is little scope for configuration beyond using the application manifest. To use the plugin, follow the [Setting up the Cloud Foundry plugin](#setting-up-the-cloud-foundry-plugin) instructions.
+If you have multiple Jenkins jobs, or jobs that run frequently, you should take care not to go over this rate limit by having Jenkins push 5 times from the same account within 5 minutes.
 
+We are looking into an alternative login method to avoid this limitation.
 
 
 ### Setting up the credentials plugin
@@ -39,7 +41,7 @@ You can now go on to either:
 
 ### Setting up custom scripts
 
-Before you do this, make sure you first [set up the credentials plugin](#setting-up-the-credentials-plugin).
+Before you set up custom scripts, make sure you first [set up the credentials plugin](#setting-up-the-credentials-plugin).
 
 Note that using the custom scripts approach exposes the password via the process command line, so it can be read by other processes running on the same machine. If this risk is not acceptable, please use the Cloud Foundry plugin described below. The Cloud Foundry project is aware of the problem and we expect they will provide a more secure login mechanism soon.
 
@@ -77,9 +79,11 @@ cf logout
 
 
 
-### Setting up the Cloud Foundry plugin
+### Setting up the Cloud Foundry Jenkins plugin
 
-Before you do this, make sure you first [set up the credentials plugin](#setting-up-the-credentials-plugin).
+Using the Cloud Foundry plugin only allows Jenkins to push your application to GOV.UK PaaS as a post-build action: the equivalent of doing a `cf login` followed by a `cf push`. There is little scope for configuration beyond using the application manifest.
+
+Before you do these steps, make sure you first [set up the credentials plugin](#setting-up-the-credentials-plugin).
 
 To install the Cloud Foundry plugin manually:
 

--- a/source/documentation/troubleshooting/lockouts.md
+++ b/source/documentation/troubleshooting/lockouts.md
@@ -1,0 +1,7 @@
+## Failed login rate limit
+
+If your Cloud Foundry account makes too many failed login attempts within a short period of time, your account will be locked for security reasons. While the account is locked, even the correct login details will not work. 
+
+Wait 5 minutes without logging in for the lock to expire. 
+
+Make sure that no automated services (such as Jenkins) are trying to log in using your account during this time.

--- a/source/documentation/troubleshooting/lockouts.md
+++ b/source/documentation/troubleshooting/lockouts.md
@@ -2,6 +2,6 @@
 
 If your Cloud Foundry account makes too many failed login attempts within a short period of time, your account will be locked for security reasons. While the account is locked, even the correct login details will not work. 
 
-Wait 5 minutes without logging in for the lock to expire. 
+Wait 5 minutes without trying to log in for the lock to expire. 
 
 Make sure that no automated services (such as Jenkins) are trying to log in using your account during this time.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -26,6 +26,7 @@ title: "GOV.UK Platform as a Service Technical Documentation"
 <%= partial 'documentation/deploying_services/postgres' %>
 <%= partial 'documentation/troubleshooting/index' %>
 <%= partial 'documentation/troubleshooting/cli' %>
+<%= partial 'documentation/troubleshooting/lockouts' %>
 <%= partial 'documentation/troubleshooting/port' %>
 <%= partial 'documentation/troubleshooting/ssh' %>
 <%= partial 'documentation/managing_apps/scaling' %>


### PR DESCRIPTION
Reorganise Jenkins docs, try to remove impression that using custom
script deployment is less secure. Document issue with login rate limit

https://www.pivotaltracker.com/story/show/136104045

"In our current jenkins docs
(https://github.com/alphagov/paas-tech-docs/blob/01a111ddb7ea95951e2f0d2
c809b317acc292fd5/source/documentation/deploying_apps/jenkins.md), we
recommend users log in every time job runs. This is so that they don't
have to handle secure storage of CF secrets (which is a file with a
logged-in token cf CLI produces after logging in). However our platform
has protection to lock accounts that log in 5 times in 5 minutes. If
someone has a lot of jenkins jobs, or small jobs that run often, they
can easily hit this limit and lock themselves out. As it has already
happened once and support request had to be risen to analyse and
resolve the situation.
We should either document this (that there is a lockout and what
criteria trigger it) or instead think about secure handling of
logged-in credentials and recommend that to users instead."