### PR TITLE
[#135421943] Add CRLF line endings to troubleshooting section

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -29,6 +29,7 @@ title: "GOV.UK Platform as a Service Technical Documentation"
 <%= partial 'documentation/troubleshooting/lockouts' %>
 <%= partial 'documentation/troubleshooting/port' %>
 <%= partial 'documentation/troubleshooting/ssh' %>
+<%= partial 'documentation/troubleshooting/line-endings' %>
 <%= partial 'documentation/managing_apps/scaling' %>
 <%= partial 'documentation/managing_apps/quotas' %>
 <%= partial 'documentation/managing_apps/redirect_all_traffic' %>


### PR DESCRIPTION
## What

Previously we added the actual prose but didn't place it here, so it didn't
appear in the built documentation.

It looks like this in my Firefox, which is less than ideal, but not much different to other terminal output sections we have.
![screen shot 2017-02-23 at 16 15 45](https://cloud.githubusercontent.com/assets/693486/23268052/794bc798-f9e4-11e6-8a03-39648d9dbc3f.png)

## How to review

Check the CRLF line endings content appears in built tech docs

## Who can review

Anyone but @bleach
