### PR TITLE
[#131250633] More detail about checking service is bound

### DIFF
--- a/source/documentation/deploying_services/postgres.md
+++ b/source/documentation/deploying_services/postgres.md
@@ -107,11 +107,19 @@ To create a service and bind it to your app:
 
     ``cf bind-service APPLICATION SERVICE_INSTANCE``
 
-    where APPLICATION is the name of a deployed instance of your application (exactly as specified in your manifest or push command), for example:
+    where APPLICATION is the name of a deployed instance of your application (exactly as specified in your manifest or push command), and SERVICE_INSTANCE is the name you gave the instance when you created it, for example:
 
     ``cf bind-service my-app my-pg-service``
 
-5. Your app should now able to access the PostgreSQL service. If the app was already running, you may need to restart the app to connect.
+5. If the app is already running, you should restage the app to make sure it connects:
+
+    ``cf restage APPLICATION``
+
+6. To confirm that the service is bound to the app, you can run:
+
+    ``cf service SERVICE_INSTANCE``
+
+    and check the ``Bound apps:`` line of the output.
 
 
 ### Accessing PostgreSQL from your app
@@ -120,9 +128,9 @@ Your app must make a [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Securit
 
 GOV.UK PaaS will automatically parse the ``VCAP_SERVICES`` [environment variable](/#system-provided-environment-variables) to get details of the  service and then set the `DATABASE_URL` variable to the first database found.
 
-Use ``cf env APPNAME`` to see the environment variables.
+Use ``cf env APPNAME`` to see the app's environment variables and confirm that the variable has been set correctly.
 
-You can check for database connection errors by viewing the recent logs with ``cf logs APPNAME --recent``.
+If your app writes database connection errors to `STDOUT` or `STDERR`, you can view recent errors with ``cf logs APPNAME --recent``.
 
 ### PostgreSQL service maintenance times
 
@@ -147,8 +155,6 @@ Please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:
 Note that data restore will not be available in the event of an RDS outage affecting the entire Amazon availability zone.
 
 For more details about how the RDS backup system works, see [Amazon's DB Instance Backups documentation](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.BackingUpAndRestoringAmazonRDSInstances.html) [external page].
-
-
 
 ### Read replicas
 

--- a/source/documentation/troubleshooting/postgres.md
+++ b/source/documentation/troubleshooting/postgres.md
@@ -1,0 +1,10 @@
+## PostgreSQL connection problems
+
+If you have trouble connecting your app to a postgres backing service:
+
+
+1. Ensure your app is making a [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) connection to the PostgreSQL service.
+2. Use ``cf service SERVICE_INSTANCE`` to check that the service is bound to the app.
+2. Use ``cf env APPNAME`` to see the app's environment variables and confirm that there is a ``VCAP_SERVICES={"postgres":`` section, indicating the app has correctly received the environment variables.
+3. Make sure your app writes database connection errors to `STDOUT` or `STDERR`, then look for recent errors with ``cf logs APPNAME --recent``.
+4. If restarting the app doesn't make it connect, try [restaging](https://docs.cloudfoundry.org/devguide/deploy-apps/start-restart-restage.html#restage) the app with ``cf restage APPNAME``.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -28,6 +28,7 @@ title: "GOV.UK Platform as a Service Technical Documentation"
 <%= partial 'documentation/troubleshooting/cli' %>
 <%= partial 'documentation/troubleshooting/port' %>
 <%= partial 'documentation/troubleshooting/ssh' %>
+<%= partial 'documentation/troubleshooting/postgres' %>
 <%= partial 'documentation/managing_apps/scaling' %>
 <%= partial 'documentation/managing_apps/quotas' %>
 <%= partial 'documentation/managing_apps/redirect_all_traffic' %>


### PR DESCRIPTION
#131250633

Provide more details about checking service is bound.
Advise using "restage" rather than "restart" to make sure it binds.


Original story: 

As a user in order to check that an app and Postgres instance have bound successfully, I want to know how to check the service status.
Acceptance Criteria
When a user follows documentation steps to bind app with a backing service, the following step should tell them how to check service status.
User Research
Users felt they only got a ‘proxy answer when checking if app + Postgres instance bound successfully