### PR TITLE
[#131250593] Add link to logs section

### DIFF
--- a/source/documentation/deploying_services/postgres.md
+++ b/source/documentation/deploying_services/postgres.md
@@ -122,7 +122,7 @@ GOV.UK PaaS will automatically parse the ``VCAP_SERVICES`` [environment variable
 
 Use ``cf env APPNAME`` to see the environment variables.
 
-You can check for database connection errors by viewing the recent logs with ``cf logs APPNAME --recent``.
+You can check for database connection errors by viewing the recent logs with ``cf logs APPNAME --recent``. See the section on [Logs](#logs) for details.
 
 ### PostgreSQL service maintenance times
 


### PR DESCRIPTION
#131250593


Acceptance Criteria
Signposting to logging documentation is included at appropriate point within ‘Creating a Postgres service’ section of the docs.
User Research
Users want more control/visibility of Postgres for troubleshooting purposes