### PR TITLE
[#136353551] Change tech-docs name to paas-tech-docs

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,6 @@
 ---
 applications:
+# Note: the app name must be kept in sync with the name used in the push script
 - name: paas-tech-docs
   memory: 64M
   path: ./build

--- a/release/push
+++ b/release/push
@@ -2,8 +2,9 @@
 
 set -eu
 
+# Note: the app name must be kept in sync with the name inside manifest.yml
 echo Deploy with zero downtime
-cf blue-green-deploy tech-docs
+cf blue-green-deploy paas-tech-docs
 
 echo Delete left over app
-cf delete -f tech-docs-old
+cf delete -f paas-tech-docs-old


### PR DESCRIPTION
# What
Story: [Deployment Pipeline for Tech Docs to cloudapps.digital](https://www.pivotaltracker.com/story/show/136353551)

paas-tech-docs is the official name in production. Also it is the one set in manifest.yml.

# How to review
Code review

# Who can review
Not me
