### PR TITLE
Fix errant non breaking space

### DIFF
--- a/source/documentation/getting_started/quick_setup_guide.md
+++ b/source/documentation/getting_started/quick_setup_guide.md
@@ -64,7 +64,7 @@ GOV.UK PaaS uses a hosting technology called Cloud Foundry. As a tenant (that is
 Once logged in, you can see the available commands by running ```cf```.
 
 
-### Deploying a test app
+### Deploying a test app
 
 To practice deploying an app, try following the process to [deploy a static site](/#deploy-a-static-site).
 


### PR DESCRIPTION
Replace an errant non breaking space – which causes the heading to be indented – with a normal space.