### PR TITLE
[#136353673 #136429263] Remove old URLs from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,7 @@
 
 This is the new technical documentation system for GOV.UK PaaS.
 
-The official docs to give out to tenants are still those hosted at https://government-paas-developer-docs.readthedocs.io/en/latest/ (powered by readthedocs) - however, that will change very shortly.
-
-The *temporary* URL for the output of the new system is https://paas-tech-docs.cloudapps.digital/ - do not publicise this, link to it, or give it to tenants. The permanent URL will be https://docs.cloud.service.gov.uk and will start working soon.
-
-Do not update the docs content on the old system. Update it here.
-
+It is published at https://docs.cloud.service.gov.uk
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the new technical documentation system for GOV.UK PaaS.
 
-It is published at https://docs.cloud.service.gov.uk
+It is published at https://docs.cloud.service.gov.uk (for technical reasons, it is also available at https://paas-tech-docs.cloudapps.digital but that is NOT the official address and you should not send cloudapps.digital URLs to tenants, link to them etc).
 
 ## Getting started
 


### PR DESCRIPTION
## What

Replace all the content about old URLs with the new URL.

The new `docs.cloud` URL was made available in Pivotal story #136353673. The
old `government-paas-developer-docs.readthedocs` URL was redirect to
`docs.cloud` in Pivotal story #136429263.

There is still an outstanding Pivotal story #139284061 to redirect
`paas-tech-docs.cloudapps` to `docs.cloud`, but I think it's sufficient to
remove the notice from the README for now.

## How to review

Check that the new content and my rationale for changing it makes sense.

## Who can review

Probably @benh-gds.