### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## What
+
+Describe what you have changed and why.
+
+## How to review
+
+Describe the steps required to test the changes.
+
+## Who can review
+
+Describe who can review the changes. Or more importantly, list the people
+that can't review, because they worked on it.


### PR DESCRIPTION
Copy the PaaS team's standard pull request template from alphagov/paas-cf.
This will pre-populate the description for new pull requests. The headings
are designed to help people review pull requests, which is more pertinent
for this repository because the ownership crosses team boundaries and it's
not always clear who should review a change and how.