### PR TITLE
[#139826733] Fix list formatting in SSH tunnel docs

### DIFF
--- a/source/documentation/troubleshooting/ssh.md
+++ b/source/documentation/troubleshooting/ssh.md
@@ -117,7 +117,6 @@ For example, you can connect directly to the PostgreSQL service bound to an appl
     ```
 
     You will need to know:
-
     + the remote host, displayed as `"host":`
     + the remote port, displayed as `"port"`.
     + the PostgreSQL username, displayed as `"username":`


### PR DESCRIPTION
## What

The extra newline was causing the nested unordered list to be rendered as a
codeblock with literal `+` characters before each line and the next ordered
list item to be rendered as `1.` instead of `2.`.

I'm not happy with the subtly of this change, but no amount of indentation
changes to the unordered list made it render correctly.

Before:

![screen shot 2017-03-14 at 10 34 30](https://cloud.githubusercontent.com/assets/260438/23896639/fdde0fa4-08a1-11e7-822a-7d9cb29a5eb8.png)

After:

![screen shot 2017-03-14 at 10 34 45](https://cloud.githubusercontent.com/assets/260438/23896640/ff8e7bf4-08a1-11e7-8033-e108fdf14798.png)

## How to review

Code review would be sufficient. But if you'd like to test it yourself:

1. Checkout the branch.
1. Run the test server with `bundle exec middleman server`
1. Check the rendering at http://localhost:4567/#creating-tcp-tunnels-with-ssh

## Who can review

Anyone. It doesn't change the copy or meaning, so I don't think it needs someone from content.