### PR TITLE
[#141785699] Update workaround SSH instructions

### DIFF
--- a/source/documentation/deploying_services/postgres.md
+++ b/source/documentation/deploying_services/postgres.md
@@ -182,7 +182,7 @@ This feature is experimental; we expect it to work and we'd like people who use 
  * You can only restore the most recent snapshot from the latest nightly backup
  * You cannot restore from a service instance that has been deleted
  * You must use the same service plan for the copy as for the original service instance
- * You must create the new service instance in the same organisation and space as the original. This is to prevent unauthorised access to data between spaces. If you need to copy data to a different organisation and/or space, you can use [`pg_dump`](https://www.postgresql.org/docs/9.5/static/backup-dump.html) and [`pg_restore`](https://www.postgresql.org/docs/9.5/static/app-pgrestore.html) via [SSH tunnels](#creating-tcp-tunnels-with-ssh). **Note**: it's not currently recommnended to use this for files > 1GB.
+ * You must create the new service instance in the same organisation and space as the original. This is to prevent unauthorised access to data between spaces. If you need to copy data to a different organisation and/or space, you can use [`pg_dump`](https://www.postgresql.org/docs/9.5/static/backup-dump.html) and [`pg_restore`](https://www.postgresql.org/docs/9.5/static/app-pgrestore.html) via [SSH tunnels](#creating-tcp-tunnels-with-ssh).
 
 To restore from a snapshot:
 
@@ -220,6 +220,3 @@ To restore from a snapshot:
     ``cf service my-pg-service-copy``
 
  4. Once the status reported by the above command is "create succeeded", you can use the instance. See [Setting up a PostgreSQL service](#setting-up-a-postgresql-service) for more details.
-
-
-

--- a/source/documentation/troubleshooting/ssh.md
+++ b/source/documentation/troubleshooting/ssh.md
@@ -76,7 +76,7 @@ cf ssh --app-instance-index 2
 
 The `cf ssh` command supports [local port forwarding](https://en.wikipedia.org/wiki/Port_forwarding#Local_port_forwarding), which allows you to create tunnels from your local system to the application instance container. This is useful when you want to connect from your local system to a backing service that is only accessible from an app running on GOV.UK PaaS.
 
-**Note**: We are aware of some problems sending more than 1GB of data through an SSH tunnel to a Cloud Foundry application. While we investigate and fix these problems, we suggest that you workaround the problem by sending no more than 1GB of data at a time.
+**Note**: We are aware of some problems sending more than 2GB of data through an SSH tunnel to a Cloud Foundry application via the `cf` command line. To work around the issue, you can [connect with the standard ssh client](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#other-ssh-access) instead.
 
 To enable local port forwarding, you can use the parameter `-L`:
 


### PR DESCRIPTION
## What

Story: [Resolve issues with large database imports](https://www.pivotaltracker.com/story/show/141785699)

We have fixed the server side issue with SSH. There is still an issue with cf cli, but the tenants can use the standard ssh client as a workaround.

## How to review

* Does is make sense?
* Did I write decent british english?

## Who can review
Not me