### PR TITLE
Remove docker and route services from limitations section

### DIFF
--- a/source/documentation/getting_started/limitations.md
+++ b/source/documentation/getting_started/limitations.md
@@ -50,18 +50,3 @@ During the beta period, there may be occasional brief periods where API access i
 If you find that a valid command is failing and the error message does not explain the problem, please wait 5 minutes before trying the command again. If the error persists for more than 5 minutes, it is unlikely to be caused by a platform update and you should contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).  
 
 We are working on a fix to prevent the interruption of API access when we update the platform.
-
-
-### Deploying Docker images is not currently enabled
-
-Cloud Foundry supports pushing a [Docker](https://www.docker.com/) image as an app. 
-
-This feature is *not* currently enabled on GOV.UK PaaS because allowing deployment from Docker images, where the root filesystem is controlled by the tenant, raises additional security concerns: see [this note from the CF developers](https://github.com/cloudfoundry/diego-design-notes/blob/c59e475020a22e244c6074f89c45b55f7b1e2867/docker-support.md#docker-in-a-multi-tenant-world) for more details.
-
-We may enable support for Docker images in the future. If you would like to be able to push Docker images, please contact our support team at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk), providing details of your use case.
-
-### Route services are currently disabled
-
-[Cloud Foundry route services](http://docs.cloudfoundry.org/services/route-services.html) [external link] are used to apply transformation or processing to requests before they reach an application.
-
-Route services are currently disabled on GOV.UK PaaS. If you'd like to discuss your use case for route services and possible workarounds, please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk)


### PR DESCRIPTION
## What

Remove docker and route services from limitations section as both features are currently enabled.

## How to review

Sanity check

## Who can review

Not @combor
