### PR TITLE
Change to show only config required to deploy

### DIFF
--- a/source/documentation/using_ci/travis.md
+++ b/source/documentation/using_ci/travis.md
@@ -32,18 +32,16 @@ travis setup cloudfoundry
 
 ### Manual setup
 
-Create `.travis.yml` and put Cloudfoundry configuration in it. If you already have a `.travis.yml` file please add the appropriate lines.
+Create `.travis.yml` and put Cloudfoundry configuration in it. If you already have a `.travis.yml` file please add the appropriate lines:
 
 ```
-language: go
-script: true
- deploy:
-   edge: true
-   provider: cloudfoundry
-   username: tests@example.com
-   api: https://api.cloud.service.gov.uk
-   organization: mydepartament
-   space: ci
+deploy:
+  edge: true
+  provider: cloudfoundry
+  username: tests@example.com
+  api: https://api.cloud.service.gov.uk
+  organization: mydepartament
+  space: ci
 ```
 
 Now you can add encrypted credentials to `.travis.yml` with the following command


### PR DESCRIPTION
What
====

Change to show only config required to deploy

It confused me that we referenced a complete .travis.yml file, but were
telling the users to add to a .travis.yml file. This changes to list
just the config required to add to .travis.yml file in order to deploy

Who can review
==============
anyone but me