### PR TITLE
[#146441331] Make custom domains anchor link relative

### DIFF
--- a/source/documentation/deploying_apps/names_routes_domains.md
+++ b/source/documentation/deploying_apps/names_routes_domains.md
@@ -53,6 +53,6 @@ There are a few possible solutions to this problem:
 
 ### Custom domains
 
-In production, you will probably want your app to be available through your own url (for example, ``yourapp.service.gov.uk``). Go to [using a custom domain](https://docs.cloud.service.gov.uk/#using-a-custom-domain) to see how to set this up. 
+In production, you will probably want your app to be available through your own url (for example, ``yourapp.service.gov.uk``). Go to [using a custom domain](#using-a-custom-domain) to see how to set this up.
 
 


### PR DESCRIPTION
## What

So that it doesn't go to the live site when you're running the documentation
service locally for development and so that linkchecker can validate whether
the anchor exists[0].

[0]: Although linkchecker isn't currently doing this for some reason.

## How to review

1. Checkout the branch: `git fetch && git checkout bugfix/146441331-make_link_relative`
1. Run the server locally: `bundle install && bundle exec middleman server`
1. Visit the changed content at http://localhost:4567/#custom-domains
1. Click the link and confirm it takes you to content at http://localhost:4567/#using-a-custom-domain

## Who can review

Anyone