### PR TITLE
Add docs on app/service deletion

### DIFF
--- a/source/documentation/deploying_apps/stopping_and_deleting_apps.md
+++ b/source/documentation/deploying_apps/stopping_and_deleting_apps.md
@@ -1,0 +1,52 @@
+## Stopping and deleting apps
+
+It’s important to know that when you perform a ``cf push`` command, there are three things that happen on the platform:
+
+1. your code is uploaded, after which a buildpack converts it to a single container, called a 'droplet', that can be run on PaaS as an app
+2. the droplet is used to start the requested number of instances of that app
+3. a route is created, connecting your app to the internet
+
+When deleting apps you need to remember aspects 1 and 3.
+
+Databases, CDNs and other services have a different lifecycle and need to be removed separately.
+
+### Stopping and starting apps
+If you temporarily want to stop your app, freeing up memory from your quota, you can use the command
+
+``cf stop [appname]``
+
+This will stop the app running (although databases and other provisioned services will still be running and chargeable). Users visiting your app's URL will get the error ``404 Not Found: Requested route ('[appname].cloudapps.digital') does not exist.``
+
+You can start a stopped app with
+
+``cf start [appname]``
+
+### Deleting apps
+
+**BEFORE YOU START: This is irreversible. We strongly recommend running the ``cf target`` command before you start: check you *are* where you think you are, and working on what you think you are working on.**
+
+If you want to remove your app completely it’s tempting to jump in with the ``cf delete`` command, but there are a few things to beware of:
+
+* Services that are used by apps do not automatically get deleted, and would still be chargeable
+* Routes between the internet and your apps need to be explicitly removed.
+
+If you have a simple app without any services the best way to delete it is
+
+``cf delete -r [APPNAME]``
+
+which will delete the app and its routes in one go. If your app does have services, please [delete them first](#deleting-services).
+
+If you accidentally delete your app without the ``-r`` option, you can delete the route manually. First confirm the details of the orphaned route by typing the ``cf routes`` command, to get a list of all active routes in the current space. This will list the space, the hostname, the overall domain (normally ``cloudapps.digital``), port, path, type and any bound apps or services. You will see your hostname listed but without an associated app. Use this information to populate the following command:
+
+``cf delete-route [domain name] --hostname [hostname]``
+
+### Deleting services
+Before deleting your app, you will need to delete any services you have provisioned for it.
+
+You can check the details of these by using the ``cf services`` command to see all active services in the current space. You will be able to see which services are bound *only* to your app - don’t delete services that other apps are also using.
+
+You can then use this information to run
+
+``cf delete-service [SERVICE INSTANCE]``
+
+When all services are removed you can then delete your app, as above.

--- a/source/documentation/getting_started/quick_setup_guide.md
+++ b/source/documentation/getting_started/quick_setup_guide.md
@@ -15,7 +15,7 @@ In order to provide you with an account, we need to store some personal data abo
 GOV.UK PaaS uses a hosting technology called Cloud Foundry. As a tenant (that is, someone who is hosting an application on the PaaS), you will use the Cloud Foundry command line client to interact with the PaaS. To set it up:
 
 1. Download and install the <a href="https://github.com/cloudfoundry/cli#downloads" target="blank">Cloud Foundry CLI for your platform </a> [external page, opens in new tab]
-    
+
      *Note:* On macOS Sierra, installing with Homebrew does not work. We recommend using the Mac binary or installer.
 
 2. To check that it installed correctly, go to the Terminal/command line/Command Prompt and run:
@@ -48,3 +48,5 @@ Once logged in, you can see the available commands by running ```cf```.
 ### Deploying a test app
 
 To practice deploying an app, try following the process to [deploy a static site](/#deploy-a-static-site).
+
+To clean up look at our instructions on [stopping and deleting apps](#stopping-and-deleting-apps).

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -20,6 +20,7 @@ title: "GOV.UK Platform as a Service Technical Documentation"
 <%= partial 'documentation/deploying_apps/deploying_rails' %>
 <%= partial 'documentation/deploying_apps/deploying_node_js' %>
 <%= partial 'documentation/deploying_apps/deploying_django' %>
+<%= partial 'documentation/deploying_apps/stopping_and_deleting_apps' %>
 <%= partial 'documentation/deploying_apps/deploying_docker_image' %>
 <%= partial 'documentation/deploying_apps/production_checklist' %>
 <%= partial 'documentation/using_ci/index' %>


### PR DESCRIPTION
Add info on stopping apps, deleting apps and services in the right
order, and also how to delete routes if you forget the -r flag.

Add a line at the end of the “deploy a simple app” in quick setup guide
to remind users they can clean up after themselves.

Content has been reviewed by @bleach while in GDoc form, although there
have been some amendments for clarity once I’ve seen it in context and
formatted.