### PR TITLE
[147125641] Adding statuspage information to tech docs

### DIFF
--- a/source/documentation/getting_started/system.md
+++ b/source/documentation/getting_started/system.md
@@ -1,0 +1,11 @@
+##System status, alerts and updates
+
+### Platform availability
+
+GOV.UK PaaS has a [system status page](https://status.cloud.service.gov.uk) showing the availability of live applications and database connectivity. 
+
+We use this system status service to let tenants know about problems with the platform, and so we recommend that you [sign up to receive alerts and updates](https://status.cloud.service.gov.uk/) - particularly if you are using the platform to host production applications.
+
+### Platform updates
+
+You can find out about changes, fixes and upgrades, and hear about new features, by joining our [announcement mailing list](https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/?hl=en#!forum/gov-uk-paas-announce). If you have trouble signing up, please contact [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) and we will add you manually. 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -9,6 +9,7 @@ title: "GOV.UK Platform as a Service Technical Documentation"
 <%= partial 'documentation/getting_started/before_you_start' %>
 <%= partial 'documentation/getting_started/quick_setup_guide' %>
 <%= partial 'documentation/getting_started/passwords' %>
+<%= partial 'documentation/getting_started/system' %>
 <%= partial 'documentation/getting_started/limitations' %>
 <%= partial 'documentation/getting_started/privacy' %>
 <%= partial 'documentation/deploying_apps/index' %>


### PR DESCRIPTION
## What

This commit adds the copy regarding the statuspage as provided by the
product team.

## How to review

1. Run `bundle install`
1. Run `bundle exec middleman server`
1. Check newly added section

## Who can review

Not me
