### PR TITLE
[#147829023] MySQL: Some libraries don't use TLS by default

### DIFF
--- a/source/documentation/deploying_services/mysql.md
+++ b/source/documentation/deploying_services/mysql.md
@@ -132,7 +132,7 @@ To create a service and bind it to your app:
 
 ### Accessing MySQL from your app
 
-Your app must make a [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) connection to the MySQL service. Most libraries use TLS by default.
+Your app must make a [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) connection to the MySQL service. Some libraries use TLS by default, but others will need to be explicitly configured.
 
 GOV.UK PaaS will automatically parse the ``VCAP_SERVICES`` [environment variable](/#system-provided-environment-variables) to get details of the  service and then set the `DATABASE_URL` variable to the first database found.
 


### PR DESCRIPTION
## What

We have found that Rails, Django and PHP all don't use TLS by default. It's
not possible to provide a database URI/URL with query parameters that
satisfies most of them. We're going to defer writing more specific
documentation for each individual language until we understand what people
need a bit better. This might result in more support requests in the
meantime.

## How to review

Check if the words make sense.

This can be merged prior to us forcing TLS support.

## Who can review

Anyone.