### PR TITLE
[SUPPORT] Change versions in NodeJS example

### DIFF
--- a/source/documentation/deploying_apps/deploying_node_js.md
+++ b/source/documentation/deploying_apps/deploying_node_js.md
@@ -49,8 +49,7 @@ This is the code for the example app we are going to use. It is a basic web serv
           "version": "0.0.1",
           "author": "Demo",
           "engines": {
-            "node": "6.1.0",
-            "npm": "2.7.4"
+            "node": "6.1.0"
           }
         }
 

--- a/source/documentation/deploying_apps/deploying_node_js.md
+++ b/source/documentation/deploying_apps/deploying_node_js.md
@@ -49,7 +49,7 @@ This is the code for the example app we are going to use. It is a basic web serv
           "version": "0.0.1",
           "author": "Demo",
           "engines": {
-            "node": "6.1.0"
+            "node": "6.11.x"
           }
         }
 


### PR DESCRIPTION
## What

### Don't specify npm version in NodeJS example

We had a support request from someone that followed this example, had to
update the versions to correspond with what PaaS currently provides, and
used:

    "engines": {
      "node": ">= 6.0.0",
      "npm": ">= 3.0.0"
    }

The nodejs-buildpack resolved this to NodeJS 7.8.0 (the latest we had at the
time) and downgraded NPM from 4.2.0 to 3.0.0 (for reasons I don't understand).
These two versions were incompatible so it failed with:

    Downloading and installing npm >= 3.0.0 (replacing version 4.2.0)...
    npm ERR! Linux 4.4.0-81-generic
    npm ERR! argv "/tmp/app/.cloudfoundry/node/bin/node" "/tmp/app/.cloudfoundry/node/bin/npm" "install" "--unsafe-perm" "--quiet" "-g" "npm@>=" "3.0.0"
    npm ERR! node v7.8.0
    npm ERR! npm  v4.2.0

    npm ERR! Cannot read property 'path' of null
    npm ERR!
    npm ERR! If you need help, you may report this error at:
    npm ERR!     <https://github.com/npm/npm/issues>

    npm ERR! Please include the following file with any support request:
    npm ERR!     /home/vcap/.npm/_logs/2017-07-13T18_56_49_981Z-debug.log
    We're unable to download the version of npm you've provided (>=).
    Please remove the npm version specification in package.json

Following the suggestion in the error of removing the npm version specification
from `package.json` does allow it to work. According to the docs this will
cause it to use the default version of npm for the NodeJS version:

- https://docs.cloudfoundry.org/buildpacks/node/index.html#npm_version
- https://nodejs.org/en/download/releases/

For this reason I think we should remove the version from our docs to make it
easier for people to get started. More experienced users, who need a specific
version of npm, could choose to add it back in themselves.


### Update NodeJS version in example

To the 6.11 LTS series provided by alphagov/paas-cf#978

I'm using the `.x` notation to say any version of `6.11` because this will
work between several buildpack updates and the buildpack prints the falling
warning when staging fails:

    Some possible problems:

    - Dangerous semver range (>) in engines.node
    http://docs.cloudfoundry.org/buildpacks/node/node-tips.html

## How to review

Follow the examples, see if they work for you, and whether my rationale for the changes makes sense.

## Who can review

Anyone.