### PR TITLE
[#146445463] Explain that custom buildpacks are now available

### DIFF
--- a/source/documentation/deploying_apps/deploying_docker_image.md
+++ b/source/documentation/deploying_apps/deploying_docker_image.md
@@ -29,6 +29,6 @@ Lastly, our support for this functionality has lower priority than usual request
 
 ### Applying security updates
 
-When your app is built with a buildpack, you are responsible only for the code of your app. The platform provides both the buildpacks and also a safe and secure root filesystem (`cflinuxfs2`). Buildpack based apps never have root access in their container, which adds another layer of security. We do periodically apply security and funcionality updates to the buildpacks, container root FS and the platform itself.
+When your app is built with a non-custom buildpack, you are responsible only for the code of your app. The platform provides both the buildpacks and also a safe and secure root filesystem (`cflinuxfs2`). Buildpack based apps never have root access in their container, which adds another layer of security. We do periodically apply security and funcionality updates to the buildpacks, container root FS and the platform itself.
 
 When your app is deployed from docker image, responsibility for the root filesystem and for the complete build of your app shifts to you. You need to ensure proper measures are applied to make your app and root image safe and with the latest security updates. We recommend you use one of the major and well supported linux distributions as your base container. This way you will be able to build an image with latest security patches easily.

--- a/source/documentation/getting_started/limitations.md
+++ b/source/documentation/getting_started/limitations.md
@@ -2,15 +2,11 @@
 
 While GOV.UK PaaS is built using Cloud Foundry technology, we don't support all Cloud Foundry features. This section explains some Cloud Foundry features that are not enabled, as well as some limitations of the beta phase.
 
-### Custom buildpacks and .NET are not supported
+### .NET is not supported with standard buildpacks
 
 Cloud Foundry uses buildpacks to provide runtime and framework support for applications in different languages. 
 
-GOV.UK PaaS does not support [custom buildpacks](https://docs.cloudfoundry.org/buildpacks/custom.html) [external link]. We support the [standard buildpacks](https://docs.cloudfoundry.org/buildpacks/) [external link] with the exception of the .NET Core buildpack as we have not yet identified a user need for it.
-
-If you want to use a custom buildpack because you need a newer version of a runtime or framework, please note that we update the standard buildpacks on a regular basis (approximately monthly).
-
-If you'd like to use custom buildpacks or the .NET Core buildpack, please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
+GOV.UK PaaS supports both [standard buildpacks](https://docs.cloudfoundry.org/buildpacks/) [external link] and [custom buildpacks](https://docs.cloudfoundry.org/buildpacks/custom.html) [external link]. Please note that the [.NET Core buildpack](https://docs.cloudfoundry.org/buildpacks/dotnet-core/index.html) [external link] is only available as a custom buildpack.
 
 ### 404s after commands that restart the app
 

--- a/source/documentation/overview/benefits.md
+++ b/source/documentation/overview/benefits.md
@@ -13,7 +13,8 @@ The platform itself will be supported 24/7 by GDS, although this does not includ
 Features of the PaaS platform currently include:
 
 *   PostgreSQL support and will include database back-ups
-*   language support through the [default Cloud Foundry buildpacks](http://docs.cloudfoundry.org/buildpacks/) [external link] except .NET Core
+*   language support through the [standard Cloud Foundry buildpacks](http://docs.cloudfoundry.org/buildpacks/) [external link] except .NET Core
+*   limited support for custom buildpacks and Docker images
 *   ability to stream application logs to Software as a Service logging platforms
 
 ### Coding in the open


### PR DESCRIPTION
## What

This is a minimal change that means that our docs remain correct.

@jonathanglassman and myself are going to follow this up with more detail around what "support" means and helping users to choose between standard buildpacks, custom buildpacks and Docker images.

## How to review

Preview the docs and verify they will be correct when https://github.com/alphagov/paas-cf/pull/989 is merged.

## Who can review

Not @bleach or @jonathanglassman 
