### PR TITLE
Document buildpacks

### DIFF
--- a/source/documentation/deploying_apps/buildpacks.md
+++ b/source/documentation/deploying_apps/buildpacks.md
@@ -12,7 +12,7 @@ Cloud Foundry uses buildpacks to provide runtime and framework support for appli
 
 We recommend using the standard buildpacks to maximise the support you will receive from GOV.UK PaaS. Using a custom buildpack or docker image will mean additional setup and maintenance costs.
 
-Refer to the [Guidance section](documentation/guidance/buildpacks.md) for further information on the different options available.
+Refer to the Guidance section for further information on the different options available.
 
 ### How to use Custom Buildpacks
 

--- a/source/documentation/deploying_apps/buildpacks.md
+++ b/source/documentation/deploying_apps/buildpacks.md
@@ -1,0 +1,51 @@
+## Buildpacks
+
+### About Buildpacks
+
+Cloud Foundry uses buildpacks to provide runtime and framework support for applications in different languages (for example ensuring your app code has both the Ruby runtime and the  Rails framework available to help it run). GOV.UK PaaS supports both standard and custom buildpacks:
+
+- [standard buildpacks](https://docs.cloudfoundry.org/buildpacks/#system-buildpacks) [external link] are buildpacks for common languages and frameworks that are supported by Cloud Foundry
+- custom buildpacks are developed by the wider community to enable hosting of applications in additional languages or frameworks
+- docker images are a packaging format, and the requirements for the app and its runtime environment are the same as for apps deployed using buildpacks
+
+### Which Buildpack should I use?
+
+We recommend using the standard buildpacks to maximise the support you will receive from GOV.UK PaaS. Using a custom buildpack or docker image will mean additional setup and maintenance costs.
+
+Refer to the Guidance section for further information on the different options available.
+
+### How to use Custom Buildpacks
+
+There are many application attribute options available when you push an app. You can use the buildpack attribute to specify a custom buildpack for your app through:
+
+- specifying the buildpack in the manifest.yml file
+- using the command line
+
+#### Specifying buildpacks in the Manifest File
+
+You can set application attribute options in a manifest.yml file in the directory from which you are running the push command. This is done in one of three ways:
+
+1. By name: MY-BUILDPACK.
+2. By GitHub URL: https://github.com/cloudfoundry/java-buildpack.git.
+3. By GitHub URL with a branch or tag: https://github.com/cloudfoundry/java-buildpack.git#v3.3.0 for the v3.3.0 tag.
+
+```
+---
+  ...
+  buildpack: buildpack_URL
+```
+
+>Command line options override the manifest; the option that overrides the custom buildpack attribute is `-b`.
+
+#### Using the Command Line to choose buildpacks
+
+Once a custom buildpack has been created, it can be pushed to either a public or private git repository. The repository URL can then be included in the command line to push your app.
+
+>If the repository is private, the push command must include https and username/password authentication
+
+- Public: `$ cf push my-new-app -b git://github.com/johndoe/my-buildpack.git`
+- Private: `$ cf push my-new-app -b https://username:password@github.com/johndoe/my-buildpack.git`
+
+The app will then be deployed to Cloud Foundry, and the buildpack will be cloned from the repository and applied to the app.
+
+>If a buildpack is specified using `cf push -b` the detect step will be skipped and as a result, no buildpack detect scripts will be run.

--- a/source/documentation/deploying_apps/buildpacks.md
+++ b/source/documentation/deploying_apps/buildpacks.md
@@ -12,7 +12,7 @@ Cloud Foundry uses buildpacks to provide runtime and framework support for appli
 
 We recommend using the standard buildpacks to maximise the support you will receive from GOV.UK PaaS. Using a custom buildpack or docker image will mean additional setup and maintenance costs.
 
-Refer to the Guidance section for further information on the different options available.
+Refer to the [Guidance section](documentation/guidance/buildpacks.md) for further information on the different options available.
 
 ### How to use Custom Buildpacks
 

--- a/source/documentation/guidance/buildpacks
+++ b/source/documentation/guidance/buildpacks
@@ -1,0 +1,48 @@
+# Guidance
+
+## Buildpacks
+If you're relatively new to cloud or have a small development team, we recommend using the standard buildpacks to maximise the support you will receive from GOV.UK PaaS.
+
+Using a custom buildpack will mean increased development and maintenance responsibilities and costs for you. If your language is not supported by standard buildpacks, we recommend that for a community supported custom buildpack that is maintained and updated by that community. We do not recommend that you create your own buildpack.
+
+We are keen to help where we can, so please contact us if you are interested in this feature. If a custom buildpack is requested by multiple tenants, we will look to improving our support in this area.
+
+### Responsibilities
+
+Your responsibilities differ depending on whether you use a standard buildpack, custom buildpack or docker image to deploy your app.
+
+#### Standard Buildpack
+You are only responsible for the app code and its dependencies.
+
+#### Custom Buildpacks
+
+You are responsible for managing this custom buildpack as well as the app code and its dependencies. This applies both in setting up the app, and running it in production.
+
+When setting up the app:
+
+- Do your own due diligence on finding a maintained and supported custom buildpack so that you have a community to call upon in the case of problems
+- Test deploying with the buildpack early in your build process, not just before go-live
+
+When running the app in production:
+
+- Ensure you have sufficient time to fix issues yourself as using them for deadline-driven development may be risky
+Regularly maintain your buildpack to update your runtime and dependencies as new security vulnerabilities are discovered and fixed
+- We may not be able to offer support for P1 or out-of-hours incidents; standard SLAs will not apply
+
+#### Docker Images
+
+You are responsible for your docker container and custom image. Learn about this [experimental feature](https://docs.cloud.service.gov.uk/#deploy-a-docker-image-experimental).
+
+### Custom Buildpacks compared to Docker Images
+
+Custom buildpacks provide some advantages over choosing a Docker solution:
+
+- they are not dependent on [Docker Hub](https://hub.docker.com/) availability
+a single way to specify app dependencies
+- large variety of open source buildpacks, meaning your deployment pipeline doesn’t need to include docker image creation
+- it is designed for 12-factor; some Docker images may contain databases or other forms of storage that should be provisioned as an external backing service
+
+Docker Images also provide some advantages over custom buildpacks:
+
+- the same image can be run locally on developer machines, or on any Linux-based machine
+- exactly the same Docker image can be promoted between environments as an immutable asset, rather than being rebuilt each time (CF support for this is still experimental)

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -13,6 +13,7 @@ title: "GOV.UK Platform as a Service Technical Documentation"
 <%= partial 'documentation/getting_started/limitations' %>
 <%= partial 'documentation/getting_started/privacy' %>
 <%= partial 'documentation/deploying_apps/index' %>
+<%= partial 'documentation/deploying_apps/buildpacks' %>
 <%= partial 'documentation/deploying_apps/excluding_files' %>
 <%= partial 'documentation/deploying_apps/env_variables' %>
 <%= partial 'documentation/deploying_apps/orgs_spaces_targets' %>
@@ -42,3 +43,4 @@ title: "GOV.UK Platform as a Service Technical Documentation"
 <%= partial 'documentation/managing_apps/redirect_all_traffic' %>
 <%= partial 'documentation/managing_users/user_accounts' %>
 <%= partial 'documentation/managing_users/user_lifecycle' %>
+<%= partial 'documentation/guidance/buildpacks' %>


### PR DESCRIPTION
Added content around standard and custom buildpacks
- New section under Deploying Apps which defines buildpacks and specifies how to use custom buildpacks
- New section, Guidance, at the bottom of the document, which provides around when you should and should not use custom buildpacks, and some advantages of them compared to docker images

This is the first draft and can be iterated; I'll speak to people next week about expanding the content around the responsibilities of supporting a custom buildpack or Docker image, and what responsibilities apply to running an app in production long term.

Please review and see if material and guidance are correct or need any amends or additional content.

Anyone apart from me can review this.
