### PR TITLE
Add sections for PostgreSQL, MySQL and MongoDB

### DIFF
--- a/source/documentation/deploying_services/database_services.md
+++ b/source/documentation/deploying_services/database_services.md
@@ -6,6 +6,20 @@ In Cloud Foundry, each service may have multiple plans available with different 
 
 Currently, GOV.UK PaaS offers a service for PostgreSQL, MySQL and MongoDB, with multiple plans available. Please note that MongoDB is currently only available through private beta.
 
+## PostgreSQL
+
+PostgreSQL is a general purpose and object-relational database management system. It allows you to add custom functions developed using different programming languages such as C/C++ and Java, and is designed to be extensible.
+
+## MySQL
+
+MySQL is an open source relational database management system that uses Structured Query Language (SQL).
+
+## MongoDB
+
+MongoDB is an open-source cross-platform document-oriented database program that uses JSON-like documents with schemas.
+
+## Using Database Services
+
 To see the available plans, run:
 
 ```

--- a/source/documentation/deploying_services/database_services.md
+++ b/source/documentation/deploying_services/database_services.md
@@ -12,7 +12,7 @@ PostgreSQL is an object-relational database management system. It is open-source
 
 ## MySQL
 
-MySQL is an open source relational database management system that uses Structured Query Language (SQL) and is powered by Oracle.
+MySQL is an open source relational database management system that uses Structured Query Language (SQL) and is backed by Oracle.
 
 ## MongoDB
 

--- a/source/documentation/deploying_services/database_services.md
+++ b/source/documentation/deploying_services/database_services.md
@@ -8,15 +8,15 @@ Currently, GOV.UK PaaS offers a service for PostgreSQL, MySQL and MongoDB, with 
 
 ## PostgreSQL
 
-PostgreSQL is a general purpose and object-relational database management system. It allows you to add custom functions developed using different programming languages such as C/C++ and Java, and is designed to be extensible.
+PostgreSQL is an object-relational database management system. It is open-source and designed to be extensible; currently the postgis and uuid-ossp extensions are enabled. 
 
 ## MySQL
 
-MySQL is an open source relational database management system that uses Structured Query Language (SQL).
+MySQL is an open source relational database management system that uses Structured Query Language (SQL) and is powered by Oracle.
 
 ## MongoDB
 
-MongoDB is an open-source cross-platform document-oriented database program that uses JSON-like documents with schemas.
+MongoDB is an open-source cross-platform document-oriented database program. It uses JSON-like documents with schemas, and is often used for content management such as articles on [GOV.UK](https://www.gov.uk/).
 
 ## Using Database Services
 


### PR DESCRIPTION
## What

Have added small sections on each backing service with associated h2 headings. This is to call out the current backing services in the left-hand navigation so that users can scan and quickly see these sections. I have not added them as h3 headings as this would mean editing the config yaml file so that all h3 headings are in the left-hand nav which would not be a good experience for the user. Related to https://www.pivotaltracker.com/story/show/149301683 

## How to review

Check to see if any different or additional content is required in these sections i.e. any specific information that we want to call out on the different backing services.

## Who can review

Anyone but me.
