### PR TITLE
[#149301683] Deploying services section re-org

### DIFF
--- a/source/documentation/deploying_services/database_services.md
+++ b/source/documentation/deploying_services/database_services.md
@@ -1,25 +1,5 @@
 ## Using Database Services
 
-GOV.UK PaaS enables you to create a database service and bind it to your app.
-
-In Cloud Foundry, each service may have multiple plans available with different characteristics.
-
-Currently, GOV.UK PaaS offers a service for PostgreSQL, MySQL and MongoDB, with multiple plans available. Please note that MongoDB is currently only available through private beta.
-
-## PostgreSQL
-
-PostgreSQL is an object-relational database management system. It is open-source and designed to be extensible; currently the postgis and uuid-ossp extensions are enabled. 
-
-## MySQL
-
-MySQL is an open source relational database management system that uses Structured Query Language (SQL) and is backed by Oracle.
-
-## MongoDB
-
-MongoDB is an open-source cross-platform document-oriented database program. It uses JSON-like documents with schemas, and is often used for content management such as articles on [GOV.UK](https://www.gov.uk/).
-
-## Using Database Services
-
 To see the available plans, run:
 
 ```
@@ -41,14 +21,6 @@ M-HA-dedicated-X.X       20GB Storage, Dedicated Instance, Highly Available, Max
 ...
 Free                     5GB Storage, NOT BACKED UP, Dedicated Instance, Max 50 Concurrent Connections. Postgres Version X.X. DB Instance Class: db.t2.micro.                              free
 ```
-
-### Free and paid service plans
-
-Most plans are paid, meaning that we will bill you based on your usage of the service.
-
-There is a free plan available with limited storage. This should *only* be used for development or testing, not for production.
-
-Paid services may not be enabled for your organisation. If they're not enabled, when you try to set up a paid service, you'll receive the error "service instance cannot be created because paid service plans are not allowed". One of your [Org Managers](/#org-manager) must contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) to request that we enable paid services.
 
 ### Failover process
 

--- a/source/documentation/deploying_services/database_services.md
+++ b/source/documentation/deploying_services/database_services.md
@@ -1,4 +1,4 @@
-## Using Database Services
+## Using database services
 
 To see the available plans, run:
 

--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -1,20 +1,8 @@
 # Deploy a backing or routing service
 
-## Services and plans
-
 Many 12-factor applications rely on backing services such as a database, an email delivery service or a monitoring system. Routing services can be used to proxy and perform preprocessing on application requests such as caching, rate limiting or authentication.
 
-In Cloud Foundry, backing and routing services are referred to as 'services' and are available through the Cloud Foundry ``cf marketplace`` command. GOV.UK PaaS enables you to create a database service and bind it to your app. 
-
-Currently, the following database services are available in the marketplace:
-
- - PostgreSQL
- - MySQL
- - MongoDB (currently only available on private beta)
-
-Each service in the marketplace can have multiple plans available with different characteristics. For example, there are different PostgreSQL plans which vary by availability, storage capacity and encryption.
-
-Users can also define their own external services that are not available in the marketplace by using [User-Provided Service Instances](/#user-provided-service-instance).
+In Cloud Foundry, backing and routing services are referred to as 'services' and are available through the Cloud Foundry ``cf marketplace`` command. GOV.UK PaaS enables you to create a database service and bind it to your app. The available database services are detailed below.
 
 ## PostgreSQL
 
@@ -26,11 +14,17 @@ MySQL is an open source relational database management system that uses Structur
 
 ## MongoDB
 
-MongoDB is an open-source cross-platform document-oriented database program. It uses JSON-like documents with schemas, and is often used for content management such as articles on [GOV.UK](https://www.gov.uk/).
+MongoDB is an open-source cross-platform document-oriented database program. It uses JSON-like documents with schemas, and is often used for content management such as articles on [GOV.UK](https://www.gov.uk/). It currently only available on private beta.
+
+## Services and plans
+
+Each service in the marketplace can have multiple plans available with different characteristics. For example, there are different PostgreSQL plans which vary by availability, storage capacity and encryption.
+
+Users can also define their own external services that are not available in the marketplace by using [User-Provided Service Instances](/#user-provided-service-instance).
 
 ### Paid service plans
 
-Some service plans are paid: that is, you can potentially be billed by us based on your usage of the service. There is a free plan available with limited storage which should only be used for development or testing, not production.
+Some service plans are paid; you can potentially be billed by us based on your usage of the service. There is a free plan available with limited storage which should only be used for development or testing, not production.
 
 By default, access to paid plans is not enabled for a new organisation. Whether this is enabled or not is controlled by your [organisation's quota settings](/#quotas).
 

--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -4,7 +4,7 @@
 
 Many 12-factor applications rely on backing services such as a database, an email delivery service or a monitoring system. Routing services can be used to proxy and perform preprocessing on application requests such as caching, rate limiting or authentication.
 
-In Cloud Foundry, backing and routing services are referred to as 'services' and are available through the Cloud Foundry ``cf marketplace`` command.
+In Cloud Foundry, backing and routing services are referred to as 'services' and are available through the Cloud Foundry ``cf marketplace`` command. GOV.UK PaaS enables you to create a database service and bind it to your app. 
 
 Currently, the following database services are available in the marketplace:
 
@@ -12,18 +12,29 @@ Currently, the following database services are available in the marketplace:
  - MySQL
  - MongoDB (currently only available on private beta)
 
-
-Each service in the marketplace can have multiple plans available. For example, there are different PostgreSQL plans which vary by availability, storage capacity and encryption.
+Each service in the marketplace can have multiple plans available with different characteristics. For example, there are different PostgreSQL plans which vary by availability, storage capacity and encryption.
 
 Users can also define their own external services that are not available in the marketplace by using [User-Provided Service Instances](/#user-provided-service-instance).
 
+## PostgreSQL
+
+PostgreSQL is an object-relational database management system. It is open-source and designed to be extensible; currently the postgis and uuid-ossp extensions are enabled.
+
+## MySQL
+
+MySQL is an open source relational database management system that uses Structured Query Language (SQL) and is backed by Oracle.
+
+## MongoDB
+
+MongoDB is an open-source cross-platform document-oriented database program. It uses JSON-like documents with schemas, and is often used for content management such as articles on [GOV.UK](https://www.gov.uk/).
+
 ### Paid service plans
 
-Some service plans are paid: that is, you can potentially be billed by us for using them.
+Some service plans are paid: that is, you can potentially be billed by us based on your usage of the service. There is a free plan available with limited storage which should only be used for development or testing, not production.
 
 By default, access to paid plans is not enabled for a new organisation. Whether this is enabled or not is controlled by your [organisation's quota settings](/#quotas).
 
-If you try to use a paid service and receive an error stating "service instance cannot be created because paid service plans are not allowed", please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
+If paid plans are not enabled, when you try to use a paid service you will receive an error stating "service instance cannot be created because paid service plans are not allowed". One of your [Org Managers](https://docs.cloud.service.gov.uk/#org-manager) must contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) to request that we enable paid services.
 
 ### Accessing services
 


### PR DESCRIPTION
## What

- Re-organise the "Deploy a Backing or Routing Service" section to remove duplicated content.
- Remove duplicated headings within the "Deploy a Backing or Routing Service" section. These duplicated headings were mistakenly implemented when completing previous PR

## How to review

Check that re-organisation has not removed any content inadvertently or caused a change in meaning.

## Who can review

Anyone in PaaS team; have requested Dan and Tom.