### PR TITLE
Custom Domain documentation

### DIFF
--- a/source/documentation/deploying_services/use_a_custom_domain.md
+++ b/source/documentation/deploying_services/use_a_custom_domain.md
@@ -1,181 +1,151 @@
 ## Using a custom domain
 
-This section explains how to configure the domain name of your service for production applications.
+This section explains how to configure a custom domain name for your application.
 
-When you use a custom domain you can also take advantage of the following:
+To use a custom domain with PaaS, you will need to use our `cdn-route` service to set up a Content Distribution Network (CDN) that will route and [optionally cache](#caching) requests to your app.
 
-1. Fast delivery of content to your users via Content Distribution Network (CDN) caching (using [AWS CloudFront](https://aws.amazon.com/cloudfront/)).
+### Setting up a custom domain
 
-2. Encrypted user traffic via HTTPS support. This option comes with free TLS certificates with auto-renewal (using [Let's Encrypt](https://letsencrypt.org/)).
+>Before you begin, note that once you create a CDN service instance you can't update or delete it until it has been successfully configured. This means that if you make a mistake that prevents it from being successfully configured, you'll need to ask support to manually delete the service instance.
 
-### How to create an instance of this service
+1. Target the space your application is running in:
 
-To see the plans available you can run:
+    ```bash
+    cf target -o ORGNAME -s SPACENAME
+    ```
+
+2. Create a domain in your organisation (replace `ORGNAME` with your org name, and replace `example.com` with your domain):
+
+    ```bash
+    cf create-domain ORGNAME example.com
+    ```
+
+3. Map the route to your application:
+
+    ```bash
+    cf map-route APPNAME example.com
+    ```
+
+4. Create an instance of the `cdn-route` service by running the following command, replacing `my-cdn-route` with the name of your service instance, and `example.com` with your domain:
+
+    ```bash
+    cf create-service cdn-route cdn-route my-cdn-route \
+        -c '{"domain": "example.com"}'
+    ```
+
+    >This command includes `cdn-route` twice because `cdn-route` is the name of the service **and** the name of the service plan.
+
+
+5. Get the DNS information required to configure your domain by running the following command, replacing `my-cdn-route` with the name of your service instance:
+
+    ```bash
+    cf service my-cdn-route
+    ```
+    This will output the DNS information, as per this example:
+
+    ```
+    Last Operation
+    Status: create in progress
+    Message: Provisioning in progress [example.com => origin-my-paas-app.cloudapps.digital]; CNAME or ALIAS domain example.com to d3nrs0916m1mk2.cloudfront.net or create TXT record(s):
+    name: _acme-challenge.example.com., value: ngd2suc9gwUnH3btm7N6hSU7sBbNp-qYtSPYyny325E, ttl: 120
+
+    ```
+
+6. Create the TXT record using the DNS information output. This record will be used to validate your domain, and issue the TLS certificate used to encrypt traffic.
+
+    Using this example, you will create a `TXT` record for your domain named `_acme-challenge.example.com.` with a value of `ngd2suc9gwUnH3btm7N6hSU7sBbNp-qYtSPYyny325E`.
+
+7. Create the CNAME record using the DNS information output. This will direct traffic from your domain to the service.
+
+    Using this example, you will create a `CNAME` record in your DNS server pointing `example.com` to `d3nrs0916m1mk2.cloudfront.net.`
+
+You have now completed the custom domain setup process. Please note that it should take approximately one hour for domain setup to finish. If it has not finished after two hours, please refer to the [troubleshooting](#troubleshooting-custom-domains) section.
+
+>Your application is only available over HTTPS.
+
+
+### Configuring your custom domain
+
+#### Multiple domains
+
+If you have more than one domain, you can pass a comma-delimited list to the `domain` parameter. For example, to update your CDN instance to map both https://example.com and https://www.example.com you can run:
 
 ```bash
-cf marketplace -s cdn-route
-```
-
-Before you begin, note that once you create a CDN service instance you can't update or delete it until it has been successfully configured. This means if you make a mistake that prevents it from being successfully configured, you'll need to ask support to manually delete the service instance.
-
-First, target the space your application is running in:
-
-```bash
-cf target -o ORGNAME -s SPACENAME
-```
-
-Create a domain in your organisation (replace `ORGNAME` with your org name, and replace `example.com` with your domain):
-
-```bash
-cf create-domain ORGNAME example.com
-```
-
-Map the route to your app:
-
-```bash
-cf map-route APPNAME example.com
-```
-
-Create a `cdn-route` service instance by running the following command, replacing `my-cdn-route` with a name for your service instance, and `example.com` with your domain:
-
-```bash
-cf create-service cdn-route cdn-route my-cdn-route \
-    -c '{"domain": "example.com"}'
-```
-
-This command includes `cdn-route cdn-route` because `cdn-route` is the name of the service *and* the name of the service plan.
-
-If you have more than one domain you can pass a comma-delimited list to the `domain` parameter. Keep in mind that the broker will wait until all domains are CNAME'd, as explained in the next step:
-
-```bash
-cf create-service cdn-route cdn-route my-cdn-route \
+cf update-service my-cdn-route \
     -c '{"domain": "example.com,www.example.com"}'
 ```
 
 The maximum number of domains that can be associated with a single cdn-route service instance is 100.
 
-#### How to set up DNS
+#### Disabling Forwarding Cookies
 
-**Note:** If you are creating a new site on GOV.UK PaaS, or you are migrating an existing site to GOV.UK PaaS that can tolerate a small amount of downtime during the migration, you can skip the first step and proceed directly to [Create CNAME record(s)](#step-2-create-cname-record-s).
-
-##### Step 1: Create TXT record(s)
-
-Once you've created the service instance you need to retrieve the instructions to set up your DNS. Run the following command, replacing `my-cdn-route` with the service instance name you used in the previous step.
+By default cookies are forwarded to your application. You can disable this by setting the `cookies` parameter to `false`:
 
 ```bash
-$ cf service my-cdn-route
-
-Last Operation
-Status: create in progress
-Message: Provisioning in progress [example.com => origin-my-paas-app.cloudapps.digital]; CNAME or ALIAS domain example.com to d3nrs0916m1mk2.cloudfront.net or create TXT record(s):
-name: _acme-example.com., value: ngd2suc9gwUnH3btm7N6hSU7sBbNp-qYtSPYyny325E, ttl: 120
-
-```
-Create the TXT record(s) as instructed by the broker. The existence of these records will be validated by [Let's Encrypt](https://letsencrypt.org/) when issuing your certificate and will not affect your site.
-
-After the records have been created you will have to wait for up to an hour for the certificate to be provisioned. Your certificate has been provisioned when the `cf service my-cdn-route` command reports the status as `create succeeded`.
-
-```
-Last Operation
-Status: create succeeded
-Message: Service instance provisioned [example.com => origin-my-paas-app.cloudapps.digital]; CDN domain d3nrs0916m1mk2.cloudfront.net
-```
-
-It may take some time for CloudFront to serve your origin from all locations, because it is a globally distributed network. You can check in advance by sending requests to CloudFront and passing the custom domain in the `Host` header, using the example below. The CloudFront domain can be found by running `cf service my-cdn-route`.
-
-```
-curl -H "Host: <Custom domain>" https://<CloudFront domain>/
-```
-
-When this is working consistently, you can flip your DNS record to start serving content from the CDN. You may still have to wait for up to an hour to make sure the CloudFront distribution is updated everywhere.
-
-##### Step 2: Create CNAME record(s)
-
-Once the TXT records have been validated, or if you've decided to skip that step, you need to point your custom domain at the CDN. Run `cf service my-cdn-route` with the service instance name you choose.
-
-```
-Last Operation
-Status: create succeeded
-Message: Service instance provisioned [example.com => origin-my-paas-app.cloudapps.digital]; CDN domain d3nrs0916m1mk2.cloudfront.net
-```
-
-The output will include the CDN domain the broker has created for you. In this case you need to create a CNAME record in your DNS server pointing `example.com` to `d3nrs0916m1mk2.cloudfront.net.`.
-
-After the record is created wait for up to an hour for the CloudFront distribution to be provisioned and the DNS changes to propagate. Then visit your custom domain and see whether you have a valid certificate - in other words, that visiting your site in a modern browser doesn't give you a certificate warning.
-
-#### CDN Configuration Options
-
-The following table shows the values you can provide when provisioning or updating a CDN. Further information on using the headers and cookies parameters can be found in the subsections below the table.
-
-##### Options available
-
-Name | Required | Description | Default
---- | --- | --- | ---
-`domain` | *Required* | Your custom domain (or domains separated by commas) |
-`cookies` | *Optional* | Forward cookies to the origin | `true` |
-`headers` | *Optional* | A list of headers to forward to the origin | `["Host"]` |
-
-##### Cookies
-
-[Forwarding cookies to your origin](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Cookies.html) can be disabled by setting the `cookies` parameter to `false`.
-
-```bash
-cf create-service cdn-route cdn-route my-cdn-route \
+cf update-service my-cdn-route \
     -c '{"domain": "example.com", "cookies": false}'
 ```
+See the [More about how the CDN works](#more-about-how-custom-domains-work) section for details.
 
-##### Headers
+#### Forwarding Headers
 
-By default our service broker configures CloudFront to forward the `Host` header to your app. Depending on [how CloudFront handles certain headers](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#request-custom-headers-behavior) [external link], you may want to whitelist extra headers:
+By default, our service broker configures the CDN to only forward the `Host` header to your application. You can whitelist extra headers; in this example you can whitelist the `Accept` and `Authorization` headers:
 
 ```bash
-cf create-service cdn-route cdn-route my-cdn-route \
+cf update-service my-cdn-route \
     -c '{"domain": "example.com", "headers": ["Accept", "Authorization"]}'
 ```
 
 You can supply up to nine headers. If you need to allow more headers you will have to forward all headers:
 
 ```bash
-cf create-service cdn-route cdn-route my-cdn-route \
+cf update-service my-cdn-route \
     -c '{"domain": "example.com", "headers": ["*"]}'
 ```
 
-Note that forwarding headers has a negative impact on cacheability. See the [More about how the CDN works](#more-about-how-the-cdn-works) section for details.
+Note that forwarding headers has a negative impact on cacheability. See the [More about how the CDN works](#more-about-how-custom-domains-work) section for details.
 
-#### Troubleshooting
+### Removing your custom domain
 
-If your custom domain isn't working:
+If you no longer want to use your custom domain you can delete it by running the following command, replacing `my-cdn-route` with the name of your service instance:
 
-* make sure you've waited at least an hour
-* check your DNS setup to make sure you completed the CNAME record creation.
+```
+cf delete-service my-cdn-route
+```
 
-If you get the following error message when you try to update or delete a service instance:
+You may have to wait for up to an hour for the changes to complete.
+
+### Troubleshooting custom domains
+
+#### Service creation timescales
+
+Service creation usually takes approximately one hour. Whilst a service is being created, you will see the status "create in progress" reported from commands like `cf services`. If it has not finished after two hours, we recommend that you check your DNS setup to make sure you completed the CNAME record creation correctly (see step seven). If this does not solve the issue, you may need to [contact support](https://www.cloud.service.gov.uk/support.html).
+
+#### CloudFront timescales for serving your origin from all location
+
+It may take some time for CloudFront to serve your origin from all locations, because it is a globally distributed network. You can check in advance by sending requests to CloudFront and passing the custom domain in the `Host` header, using the example below. The CloudFront domain can be found by running `cf service my-cdn-route`.
+
+    ```
+    curl -H "Host: <Custom domain>" https://<CloudFront domain>/
+    ```
+
+When this is working consistently, you can flip your DNS record to start serving content from the CDN. You may still have to wait for up to an hour to make sure the CloudFront distribution is updated everywhere.
+
+#### "An operation for service instance [name] is in progress"
+
+You may get the following error message when you try to update or delete a service instance:
 
 ```
 Server error, status code: 409, error code: 60016, message: An operation for service instance [name] is in progress.
 ```
 
-this happens because you can't do anything to a service instance while it's in a pending state. A CDN service instance stays pending until it detects the CNAME or ALIAS record. If this causes a problem for you ask support to manually delete the pending instance.
+This happens because you can't do anything to a service instance while it's in a pending state. A CDN service instance stays pending until it detects the CNAME or ALIAS record. If this causes a problem for you, [contact support](https://www.cloud.service.gov.uk/support.html) to ask us to manually delete the pending instance.
 
-### How to update a service instance
+### More about how custom domains work
 
-To update a service instance, run the following command (replace `my-cdn-route` with your service instance name, and replace `example.com` with your domain):
+#### Overview
 
-```bash
-cf update-service my-cdn-route -c '{"domain": "example.com"}'
-```
-
-After the record is updated, wait up to an hour for the CloudFront distribution to be updated and the DNS changes to propagate. You may also have to clear your browser's cache if it shows the old content after the DNS changes propagate.
-
-#### When to update the DNS
-
-You only need to add a CNAME entry when you update the `domain` field. If you do, follow [How to set up DNS](#how-to-set-up-dns) again.
-
-#### Deleting a service instance
-
-After you delete an existing service instance you may have to wait for up to an hour for the changes to complete and propagate.
-
-### More about how the CDN works
+Custom domains are configured by our cdn-route service which uses sets up CloudFront distributions to proxy and/or cache requests to your application.
 
 #### Caching
 
@@ -183,8 +153,13 @@ CloudFront uses your application's `Cache-Control` or `Expires` HTTP headers to 
 
 While there is no mechanism for GOV.UK PaaS users to trigger a cache clear, [GOV.UK PaaS support](https://www.cloud.service.gov.uk/support.html) can. Cache invalidation is not instantaneous; Amazon recommends expecting a lag time of 10-15 minutes (more if there are many distinct endpoints).
 
-You can configure CloudFront to forward headers to your app, which causes CloudFront to cache multiple versions of an object based on the values in one or more request headers. See [CloudFront's documentation](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/header-caching.html#header-caching-web) [external link] for more detail. This means the more headers you forward the less caching will take place. Forwarding all headers means no caching will happen.
+You can configure CloudFront to forward headers to your application, which causes CloudFront to cache multiple versions of an object based on the values in one or more request headers. See [CloudFront's documentation](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/header-caching.html#header-caching-web) [external link] for more detail. This means the more headers you forward the less caching will take place. Forwarding all headers means no caching will happen.
 
 #### Authentication
 
-As noted above, cookies are passed through the CDN by default, meaning that cookie-based authentication will work as expected. Other headers, such as HTTP auth, are stripped by default. If you need a different configuration, see the above guidance on [CDN configuration options](#cdn-configuration-options).
+Cookie headers are forwarded to your application by default, so cookie-based authentication will work as expected. Other headers, such as HTTP auth, are stripped by default. If you need a different configuration, see the guidance on [Forwarding Headers](#forwarding-headers).
+
+#### Further information
+
+* The CloudFront documentation on headers can be found [here](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#request-custom-headers-behavior) [external link]
+* The CloudFront documentation on cookies can be found [here](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Cookies.html) [external link]


### PR DESCRIPTION
## What

Re-drafted and re-organised custom domain documentation, as per https://www.pivotaltracker.com/story/show/150299463, specifically:

- Setting up a custom domain section is now focused on minimal steps to get this task accomplished, and incorporates feedback from deskpro tickets to make it less confusing
- Configuration options, troubleshooting and custom domains supplementary information consolidated into three separate sections after the setup section
- General re-drafting of content to more high-level and applicable to variety of users

## How to review

Check that the setup of custom domain documentation makes sense.

## Who can review

Anyone apart from Jon Glassman or Chris Farmiloe
