### PR TITLE
[Support] Add setting of DEPS_DIR to ssh profile instructions.

### DIFF
--- a/source/documentation/troubleshooting/ssh.md
+++ b/source/documentation/troubleshooting/ssh.md
@@ -19,6 +19,7 @@ SSH is enabled by default. In most cases, you will find that you can SSH directl
 2. For some tasks to work, you need to set up the interactive SSH session to match the buildpack environment. To do this, run:
 
     ```
+    export DEPS_DIR=/home/vcap/deps
     export HOME=/home/vcap/app
     [ -d ~/.profile.d ] && for f in ~/.profile.d/*; do source $f; done
     source /home/vcap/app/.profile


### PR DESCRIPTION
## What

The buildpack launcher process that starts the application sets this
environment variable[1] before sourcinf the profile files as part of
launching the app. The diego ssh handler doesn't set this. This means
that for buildpacks that don't override this in their own .profile files
the environment won't work. The Python buildpack is an example, and
means that it's somewhat tricky to run tasks against the app (eg
Django's manage.py).

[1]https://github.com/cloudfoundry/buildpackapplifecycle/blob/master/launcher/main.go#L37-L40

This arose from a support ticket - 8202.

## How to review

Verify that the change makes sense.

## Who can review

Not me.