### PR TITLE
[#139841751] Take out non-working http notification

### DIFF
--- a/source/documentation/deploying_apps/deploying_static_sites.md
+++ b/source/documentation/deploying_apps/deploying_static_sites.md
@@ -53,9 +53,6 @@ These steps assume you have already carried out the setup process explained in t
 
 The site should now be live at `https://APPNAME.cloudapps.digital`.
 
-**Note:** The `http://` version of the URL will not work. You must enter `https://`.
-
-
 ###Adding more instances
 
 For a production service, you should run at least two instances of the app to ensure availability.


### PR DESCRIPTION
## What

Now that we've implemented a redirect from HTTP to HTTPS for all of our
routes, the lines informing users about apps not working under `http://`
are no longer relevant.

We aim to remove any information which may be false to prevent confusion
of our users.

## How to review

- Check if the change  only removes appropriate lines
- Check if there are no more false information around this topic
