### PR TITLE
update to reflect cf buildpacks command

### DIFF
--- a/source/documentation/deploying_apps/buildpacks.md
+++ b/source/documentation/deploying_apps/buildpacks.md
@@ -4,7 +4,7 @@
 
 Cloud Foundry uses buildpacks to provide runtime and framework support for applications in different languages (for example ensuring your app code has both the Ruby runtime and the  Rails framework available to help it run). GOV.UK PaaS supports both standard and custom buildpacks:
 
-- [standard buildpacks](https://docs.cloudfoundry.org/buildpacks/#system-buildpacks) [external link] are buildpacks for common languages and frameworks that are supported by Cloud Foundry
+- [standard buildpacks](https://docs.cloudfoundry.org/buildpacks/#system-buildpacks) [external link] are buildpacks for common languages and frameworks that are supported by Cloud Foundry. You can check the installed buildpacks and their versions by running `cf buildpacks`.
 - custom buildpacks are developed by the wider community to enable hosting of applications in additional languages or frameworks
 - docker images are a packaging format, and the requirements for the app and its runtime environment are the same as for apps deployed using buildpacks
 


### PR DESCRIPTION
## What
Update documentation to reflect that `cf buildpacks` can be used to check installed buildpacks and version numbers.

## How to review

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).

