### PR TITLE
Check ~/.profile exists before sourcing it

### DIFF
--- a/source/documentation/troubleshooting/ssh.md
+++ b/source/documentation/troubleshooting/ssh.md
@@ -22,7 +22,7 @@ SSH is enabled by default. In most cases, you will find that you can SSH directl
     export DEPS_DIR=/home/vcap/deps
     export HOME=/home/vcap/app
     [ -d ~/.profile.d ] && for f in ~/.profile.d/*; do source $f; done
-    source /home/vcap/app/.profile
+    [ -f ~/.profile ] && source ~/.profile
     ```
 
     You need to run this every time you start an SSH session.


### PR DESCRIPTION
## What

Updated one of the commands a user needs to run to setup their environment when ssh-ing onto an instance to be more defensive.

The reason for the change is that bash complains that the file doesn't exist, which, although not a big issue, it could easily be avoided.

## How to review

1. Copy and paste the new command after you ssh'd onto an instance to ensure that existing functionality didn't break.


## Who can review

Anyone.