### PR TITLE
Update Logstash filter to create fields for app/space/org

### DIFF
--- a/source/documentation/troubleshooting/index.md
+++ b/source/documentation/troubleshooting/index.md
@@ -72,6 +72,13 @@ filter {
         }
     }
 
+    # Cloud Foundry passes the app name, space and organisation in the syslog_host
+    # Filtering them into separate fields makes it easier to query multiple apps in a single Kibana instance
+    dissect {
+        mapping => { "syslog_host" => "%{[cf][org]}.%{[cf][space]}.%{[cf][app]}" }
+        tag_on_failure => ["_sysloghostdissectfailure"]
+    }
+
     # Cloud Foundry gorouter logs
     if [syslog_proc] =~ "RTR" {
         mutate { replace => { "type" => "gorouter" } }


### PR DESCRIPTION
## What
Update Logstash filter to create fields for app/space/org

We found syslog_host contained these fields but it caused some confusion as it
isn't the most obvious place to find the app name.

Creating separate fields for these will hopefully be more intuitive and make it
easier to produce queries when dealing with multiple apps shipping logs to a
single ELK stack.

## How to review

Describe the steps required to test the changes.

1. Apply this configuration to an ELK stack
2. Ship logs to that ELK stack from CloudFoundry
3. Look in Kibana for the app / space / org fields

## Who can review

Anyone familiar with logstash configuration.
