### PR TITLE
[#152653609] Fix indentation for metrics exporter ordered list

### DIFF
--- a/source/documentation/monitoring_apps/metrics.md
+++ b/source/documentation/monitoring_apps/metrics.md
@@ -21,16 +21,16 @@ To set up the metrics app:
 2. [Push the metrics exporter app](/#deployment-overview) to Cloud Foundry without starting the app by running `cf push --no-start metric-exporter`.
 3. Set the following mandatory environment variables in the metrics exporter app using `cf set-env metric-exporter NAME VALUE`:
 
-|Name|Value|
-|:---|:---|
-|`API_ENDPOINT`|Use `https://api.cloud.service.gov.uk`|
-|`STATSD_ENDPOINT`|StatsD endpoint|
-|`USERNAME`|Cloud Foundry User|
-|`PASSWORD`|Cloud Foundry Password|
+	|Name|Value|
+	|:---|:---|
+	|`API_ENDPOINT`|Use `https://api.cloud.service.gov.uk`|
+	|`STATSD_ENDPOINT`|StatsD endpoint|
+	|`USERNAME`|Cloud Foundry User|
+	|`PASSWORD`|Cloud Foundry Password|
 
-You should use the `cf set-env` command for these mandatory variables as they contain secret information, and this method will keep them secure. 
+	You should use the `cf set-env` command for these mandatory variables as they contain secret information, and this method will keep them secure. 
 
-You can also set environment variables by amending the manifest file. We recommend that you use this method for optional environment variables that do not contain secret information. Refer to the [https://github.com/alphagov/paas-cf-apps-statsd](https://github.com/alphagov/paas-cf-apps-statsd) repository for more information.
+	You can also set environment variables by amending the manifest file. We recommend that you use this method for optional environment variables that do not contain secret information. Refer to the [https://github.com/alphagov/paas-cf-apps-statsd](https://github.com/alphagov/paas-cf-apps-statsd) repository for more information.
 
 4. Start your app by running `cf start metric-exporter`.
 


### PR DESCRIPTION
## What

The paragraphs in step 3 were not indented, so it was not clear to
see they were only relevant to step 3. The knock-on effect of this
was step 4 actually rendered as step 1, which was incorrect.

## How to review

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).

## Who can review

Not me
