### PR TITLE
[#153084314] Update the metrics exporter repository urls

### DIFF
--- a/source/documentation/monitoring_apps/metrics.md
+++ b/source/documentation/monitoring_apps/metrics.md
@@ -17,7 +17,7 @@ We recommend that the separate Cloud Foundry account uses the [`SpaceAuditor` ro
 
 To set up the metrics app:
 
-1. Clone the [https://github.com/alphagov/paas-cf-apps-statsd](https://github.com/alphagov/paas-cf-apps-statsd) repository.
+1. Clone the [https://github.com/alphagov/paas-metric-exporter](https://github.com/alphagov/paas-metric-exporter) repository.
 2. [Push the metrics exporter app](/#deployment-overview) to Cloud Foundry without starting the app by running `cf push --no-start metric-exporter`.
 3. Set the following mandatory environment variables in the metrics exporter app using `cf set-env metric-exporter NAME VALUE`:
 
@@ -28,9 +28,9 @@ To set up the metrics app:
 	|`USERNAME`|Cloud Foundry User|
 	|`PASSWORD`|Cloud Foundry Password|
 
-	You should use the `cf set-env` command for these mandatory variables as they contain secret information, and this method will keep them secure. 
+	You should use the `cf set-env` command for these mandatory variables as they contain secret information, and this method will keep them secure.
 
-	You can also set environment variables by amending the manifest file. We recommend that you use this method for optional environment variables that do not contain secret information. Refer to the [https://github.com/alphagov/paas-cf-apps-statsd](https://github.com/alphagov/paas-cf-apps-statsd) repository for more information.
+	You can also set environment variables by amending the manifest file. We recommend that you use this method for optional environment variables that do not contain secret information. Refer to the [https://github.com/alphagov/paas-metric-exporter](https://github.com/alphagov/paas-metric-exporter) repository for more information.
 
 4. Start your app by running `cf start metric-exporter`.
 


### PR DESCRIPTION
## What

We will rename the paas-cf-apps-statsd repository to paas-metric-exporter and the Tech docs should reflect this change.
We decided to rename the repo to metric-exporter instead of metrics-exporter as the application name is already metric-exporter and we wanted to keep it consistent.

## How to review

Sanity check.

## Who can review

Not @46bit or @bandesz
