### PR TITLE
[#148415719] Add docs about tracing requests to troubleshooting (Zipkin)

### DIFF
--- a/source/documentation/troubleshooting/tracing.md
+++ b/source/documentation/troubleshooting/tracing.md
@@ -1,0 +1,9 @@
+## Tracing HTTP requests
+
+The Cloud Foundry router automatically adds Zipkin-compatible headers to the incoming HTTP requests so you can match those with your application's responses.
+
+> Zipkin is a tracing system that enables app developers to troubleshoot failures or latency issues. Zipkin provides the ability to trace requests and responses across distributed systems. See [Zipkin.io](https://zipkin.io) [external link] for more information.
+
+To trace app requests and responses in Cloud Foundry, apps must also log Zipkin headers.
+
+After adding Zipkin HTTP headers to app logs, developers can use ```cf logs myapp``` to correlate the trace and span ids logged by the Cloud Foundry router with the trace ids logged by their app. To correlate trace IDs for a request through multiple apps, each app must forward appropriate values for the headers with requests to other applications.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -48,3 +48,4 @@ title: "GOV.UK Platform as a Service Technical Documentation"
 <%= partial 'documentation/troubleshooting/port' %>
 <%= partial 'documentation/troubleshooting/postgres' %>
 <%= partial 'documentation/troubleshooting/line-endings' %>
+<%= partial 'documentation/troubleshooting/tracing' %>


### PR DESCRIPTION
## What

Zipkin was enabled in the Cloud Foundry router which allows developers to trace HTTP requests and responses. We want our tenants to know about this feature.

## How to review

Read the Troubleshooting/Tracing requests paragraph and check if it makes sense.

## Who can review

Not @bandesz 
