### PR TITLE
Remove Redis High Availability content

### DIFF
--- a/source/documentation/deploying_services/database_services.md
+++ b/source/documentation/deploying_services/database_services.md
@@ -46,10 +46,6 @@ MongoDB uses replica sets i.e. clusters of MongoDB servers that replicate the co
 
 >Your Mongo instances are backed up automatically, but are not yet directly available to tenants. Please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) if you need to recover a backup or want to know when related features will be in our roadmap.
 
-#### High availability plans - Redis
-
-Visit the [Redis on Compose documentation](https://help.compose.com/docs/redis-on-compose#section-high-availability-and-failover-details) [external link] to see information about the availability and failover details for the Redis service.
-
 #### High availability plans - Elasticsearch
 
 Visit the [Elasticsearch on Compose documentation](https://help.compose.com/docs/elasticsearch-on-compose#section-high-availability-and-failover-details) [external link] to see information about the availability and failover details for the Elasticsearch service.


### PR DESCRIPTION
## What

Removed Redis High Availability content (https://docs.cloud.service.gov.uk/#high-availability-plans-redis) as we are not using Compose with Redis, as per story https://www.pivotaltracker.com/story/show/153435654

## How to review

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Check if any other redis content needs to change

## Who can review

Anyone except Jon Glassman
