### PR TITLE
Fix unordered list in snapshot instructions

### DIFF
--- a/source/documentation/deploying_services/database_services.md
+++ b/source/documentation/deploying_services/database_services.md
@@ -245,9 +245,9 @@ To restore from a snapshot:
     ``cf create-service postgres PLAN NEW_SERVICE_INSTANCE -c '{"restore_from_latest_snapshot_of": "GUID"}'``
 
     where:
-        + PLAN is the identifier for the plan used in the original instance; you can find out what this is using `cf service SERVICE_INSTANCE`
-        + NEW_SERVICE_INSTANCE is a unique, descriptive name for this new instance (not the name of the original)
-        + GUID is the `GUID` from step 1
+      + PLAN is the identifier for the plan used in the original instance; you can find out what this is using `cf service SERVICE_INSTANCE`
+      + NEW_SERVICE_INSTANCE is a unique, descriptive name for this new instance (not the name of the original)
+      + GUID is the `GUID` from step 1
 
     For example:
 


### PR DESCRIPTION


## What

Fix unordered list in snapshot instructions. This was at the wrong indentation level which caused it to be rendered as a single sentence. Pulling it back 2 spaces fixes it.

Henry and I used these instructions while working on a story but overlooked this part because I was too lazy to read the long sentence. I realised after that the plan needs to match.

### Before

![screen shot 2017-12-12 at 15 05 56](https://user-images.githubusercontent.com/260438/33891544-23c1bba2-df4e-11e7-977f-3093d90ac1b9.png)

### After

![screen shot 2017-12-12 at 15 06 16](https://user-images.githubusercontent.com/260438/33891547-25eae8e0-df4e-11e7-8474-c41a697532f1.png)

## How to review

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Merge.

## Who can review

Anyone.