### PR TITLE
[#152632922] Remove file extensions from product page links

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -10,10 +10,10 @@ phase: Beta
 # Links to show on right-hand-side of header
 header_links:
   About: https://www.cloud.service.gov.uk
-  Features: https://www.cloud.service.gov.uk/features.html
-  Roadmap: https://www.cloud.service.gov.uk/roadmap.html
+  Features: https://www.cloud.service.gov.uk/features
+  Roadmap: https://www.cloud.service.gov.uk/roadmap
   Documentation: /
-  Support: https://www.cloud.service.gov.uk/support.html
+  Support: https://www.cloud.service.gov.uk/support
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
 ga_tracking_id: UA-43115970-5

--- a/source/documentation/deploying_services/use_a_custom_domain.md
+++ b/source/documentation/deploying_services/use_a_custom_domain.md
@@ -119,7 +119,7 @@ You may have to wait for up to an hour for the changes to complete.
 
 #### Service creation timescales
 
-Service creation usually takes approximately one hour. Whilst a service is being created, you will see the status "create in progress" reported from commands like `cf services`. If it has not finished after two hours, we recommend that you check your DNS setup to make sure you completed the CNAME record creation correctly (see step seven). If this does not solve the issue, you may need to [contact support](https://www.cloud.service.gov.uk/support.html).
+Service creation usually takes approximately one hour. Whilst a service is being created, you will see the status "create in progress" reported from commands like `cf services`. If it has not finished after two hours, we recommend that you check your DNS setup to make sure you completed the CNAME record creation correctly (see step seven). If this does not solve the issue, you may need to [contact support](https://www.cloud.service.gov.uk/support).
 
 #### CloudFront timescales for serving your origin from all location
 
@@ -139,7 +139,7 @@ You may get the following error message when you try to update or delete a servi
 Server error, status code: 409, error code: 60016, message: An operation for service instance [name] is in progress.
 ```
 
-This happens because you can't do anything to a service instance while it's in a pending state. A CDN service instance stays pending until it detects the CNAME or ALIAS record. If this causes a problem for you, [contact support](https://www.cloud.service.gov.uk/support.html) to ask us to manually delete the pending instance.
+This happens because you can't do anything to a service instance while it's in a pending state. A CDN service instance stays pending until it detects the CNAME or ALIAS record. If this causes a problem for you, [contact support](https://www.cloud.service.gov.uk/support) to ask us to manually delete the pending instance.
 
 ### More about how custom domains work
 
@@ -151,7 +151,7 @@ Custom domains are configured by our cdn-route service which uses sets up CloudF
 
 CloudFront uses your application's `Cache-Control` or `Expires` HTTP headers to determine [how long to cache content](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html). If your application does not provide these headers, CloudFront will use a default timeout of **24 hours**. This can be particularly confusing as different requests might be routed to different CloudFront Edge endpoints.
 
-While there is no mechanism for GOV.UK PaaS users to trigger a cache clear, [GOV.UK PaaS support](https://www.cloud.service.gov.uk/support.html) can. Cache invalidation is not instantaneous; Amazon recommends expecting a lag time of 10-15 minutes (more if there are many distinct endpoints).
+While there is no mechanism for GOV.UK PaaS users to trigger a cache clear, [GOV.UK PaaS support](https://www.cloud.service.gov.uk/support) can. Cache invalidation is not instantaneous; Amazon recommends expecting a lag time of 10-15 minutes (more if there are many distinct endpoints).
 
 You can configure CloudFront to forward headers to your application, which causes CloudFront to cache multiple versions of an object based on the values in one or more request headers. See [CloudFront's documentation](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/header-caching.html#header-caching-web) [external link] for more detail. This means the more headers you forward the less caching will take place. Forwarding all headers means no caching will happen.
 


### PR DESCRIPTION
## What

Links to the product pages shouldn't have a file extension because
Middleman renders them without and that's how they are referenced in the
product pages themselves.

Most of these are in the header, but there were also some references to the
support page within the custom domain documentation.

These also caused the requests to redirect off of `service.gov.uk` and go to
`cloudapps.digital` because of a bug that we're fixing in a separate story.

## How to review

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Follow all of the links in the top-right header and check that they work.
1. Follow all of the support links in [/#using-a-custom-domain](http://localhost:4567/#using-a-custom-domain) and check that they work.

## Who can review

Anyone.