### PR TITLE
[#153091168] Deploy with docs.cloud.service.gov.uk hostname

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 .DS_Store
 
 Staticfile.auth
+
+modified_manifest.yml

--- a/Gemfile
+++ b/Gemfile
@@ -19,3 +19,5 @@ gem 'middleman-syntax', '~> 3.0.0'
 gem 'redcarpet', '~> 3.3.2'
 
 gem 'table_of_contents', git: 'https://github.com/alphagov/table_of_contents.git', ref: 'f6d37fe1e837cebf7354abafd891f755148e7efa'
+
+gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
       sass (>= 3.2, < 3.5)
     concurrent-ruby (1.0.2)
     contracts (0.13.0)
+    diff-lcs (1.3)
     dotenv (2.1.1)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
@@ -131,6 +132,19 @@ GEM
       ffi (>= 0.5.0)
     redcarpet (3.3.4)
     rouge (2.0.7)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.0)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.0)
     sass (3.4.22)
     servolux (0.12.0)
     sprockets (3.7.0)
@@ -155,9 +169,10 @@ DEPENDENCIES
   middleman-sprockets (~> 4.0.0)
   middleman-syntax (~> 3.0.0)
   redcarpet (~> 3.3.2)
+  rspec
   table_of_contents!
   tzinfo-data
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   1.13.7
+   1.15.4

--- a/release/generate-manifest
+++ b/release/generate-manifest
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+require 'yaml'
+
+cf_system_dns_root = ENV['CF_API'].sub('https://api.', '')
+
+manifest = YAML.load($stdin.read)
+manifest['applications'].each { |app|
+  app['routes'] ||= []
+  app['routes'] << { 'route' => 'docs.' + cf_system_dns_root }
+  app['routes'] << { 'route' => 'paas-tech-docs.cloudapps.digital' }
+}
+puts manifest.to_yaml

--- a/release/push
+++ b/release/push
@@ -2,9 +2,12 @@
 
 set -eu
 
-# Note: the app name must be kept in sync with the name inside manifest.yml
-echo Deploy with zero downtime
-cf blue-green-deploy paas-tech-docs
+echo "Creating manifest"
+export CF_API
+release/generate-manifest \
+    < manifest.yml \
+    > modified_manifest.yml
 
-echo Delete left over app
-cf delete -f paas-tech-docs-old
+echo "Deploy with zero downtime"
+cf zero-downtime-push paas-tech-docs \
+    -f modified_manifest.yml

--- a/release/test
+++ b/release/test
@@ -8,3 +8,5 @@ cd "${ROOT_DIR}"
 bundle exec middleman build --verbose
 
 linkchecker ./build/
+
+bundle exec rspec

--- a/spec/release_spec.rb
+++ b/spec/release_spec.rb
@@ -1,0 +1,33 @@
+require 'open3'
+require 'pathname'
+require 'yaml'
+
+describe "generating a manifest" do
+  let(:dir) { Pathname(File.absolute_path(__dir__) + '/..') }
+  let(:manifest_template) { dir.join('manifest.yml').read }
+
+  let(:new_manifest) {
+    cmd = dir.join('release', 'generate-manifest')
+
+    stdout, stderr, status = Open3.capture3(
+      {
+        'CF_API' => 'https://api.foo.bar.baz',
+      },
+      cmd.to_s,
+      stdin_data: manifest_template
+    )
+
+    expect(stderr).to be_empty
+    YAML.load(stdout)
+  }
+
+  it "adds a www.SYSTEM_DOMAIN route" do
+    expect(new_manifest['applications'][0]['routes']).
+      to include({ 'route' => 'docs.foo.bar.baz' })
+  end
+
+  it "adds the cloudapps.digital route" do
+    expect(new_manifest['applications'][0]['routes']).
+      to include({ 'route' => 'paas-tech-docs.cloudapps.digital' })
+  end
+end


### PR DESCRIPTION
## What

This adds a new hostname to the deployed app, which in production will be `docs.cloud.service.gov.uk` and in development would be `docs.${DEPLOY_ENV}.dev.cloudpipeline.digital`. This keeps it in line with the product page and is a step towards removing the `paas-tech-docs.cloudapps.digital` host.

## How to review

Code review

## Who can review

Not @46bit @camelpunch 