### PR TITLE
[#153177409] Update tech-docs-template

### DIFF
--- a/.template_version
+++ b/.template_version
@@ -1,3 +1,3 @@
 ---
 :remote: https://github.com/alphagov/tech-docs-template.git
-:revision: head
+:revision: eb730095465c751462a691350f6968227f8aa325

--- a/source/stylesheets/modules/_app-pane.scss
+++ b/source/stylesheets/modules/_app-pane.scss
@@ -49,7 +49,8 @@
       }
     }
 
-    .no-flexbox.no-flexboxtweener {
+    .no-flexbox.no-flexboxtweener,
+    .no-js {
       .app-pane__toc {
         float: left;
         width: $toc-width;


### PR DESCRIPTION
## What

Using the following command and accepting all changes except `.gitignore`
which would have partially reverted 2f9a75c:

    bundle exec middleman init . -T alphagov/tech-docs-template

The update address two issues that have been fixed upstream:

- alphagov/tech-docs-template#118 to re-add H1 dividers which we already
  applied in a5ab659
- alphagov/tech-docs-template#120 to render correctly when Javascript is
  disabled

## How to review

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Check that there are thick horizontal lines before each H1 as shown in the screenshots of alphagov/tech-docs-template#118
1. Check that the page renders when Javascript is disabled ([see how to disable it from Chrome](https://stackoverflow.com/a/13405409)) as shown in the screenshots of alphagov/tech-docs-template#120
1. Check that the revision in `.template_version` matches the HEAD of `alphagov/tech-docs-template` which includes the fixes.

## Who can review

Anyone.