### PR TITLE
[#153744593] More than one instance

### DIFF
--- a/source/documentation/deploying_apps/production_checklist.md
+++ b/source/documentation/deploying_apps/production_checklist.md
@@ -4,6 +4,6 @@ Before deploying an app for production use, check the following:
 
 1. If your app uses a [backing service](/#deploy-a-backing-or-routing-service), make sure that you have selected the high-availability plan for the service instance.
 1. You have [a domain name](https://www.gov.uk/service-manual/technology/get-a-domain-name) for your service.
-1. You are running at least two instances of the app to ensure availability. Use ``cf scale APPNAME -i 2`` or amend the manifest file to add an extra running instance; see [Scaling](/#scaling) for more information.
+1. You are running more than one instance of the app to ensure availability. Use ``cf scale APPNAME -i INSTANCES`` or amend the manifest file to add more running instances; see [Scaling](/#scaling) for more information.
 1. You are prepared to use a [blue-green deployment process](https://docs.cloudfoundry.org/devguide/deploy-apps/blue-green.html) [external link] for when the app needs to be updated or restarted (this avoids problems due to a known issue with the PaaS that can generate transient 404 errors).
 1. You have configured a [health check](https://docs.cloudfoundry.org/devguide/deploy-apps/healthchecks.html) [external link] by setting `health-check-type` to `http` and setting `health-check-http-endpoint` to an appropriate endpoint for your app.

--- a/source/documentation/managing_apps/quotas.md
+++ b/source/documentation/managing_apps/quotas.md
@@ -57,7 +57,7 @@ Use the following commands to set application quota options (in each pair below,
 
 	Sets the number of application instances to launch. Each additional instance receives the same memory and disk reservation. An application with a manifest specifying `memory: 256M` and `instances: 4` would reserve 1GB (256M x 4) total.
 
-	For a production application, you should always launch at least two instances. See [Scaling](/#scaling) for more information.
+	For a production application, you should always launch more than one instance. See [Scaling](/#scaling) for more information.
 
 #### Memory share and compute share
 

--- a/source/documentation/managing_apps/scaling.md
+++ b/source/documentation/managing_apps/scaling.md
@@ -12,10 +12,12 @@ from the command line.
 
 If you are anticipating a spike in demand for a service hosted on GOV.UK PaaS, please contact us well in advance at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
 
-###Increasing instances
+### Increasing instances
 
-You can change the number of instances of your app running in parallel.
-Incoming requests are automatically load-balanced across all instances.
+You can change the number of instances of your app running in parallel. Running more than one app instance:
+
+- allows your app to handle increased traffic and demand as incoming requests are automatically load-balanced across all instances
+- helps maintain high availability and decreases the likelihood that the failure of a single component will take down your app
 
 For example, this command sets the number of running instances to five:
 
@@ -29,10 +31,9 @@ You can also use the manifest to set the number of instances that will start whe
   instances: 2
 ```
 
+For a production app, you should always run more than one instance.
 
-For a production app, you should always have at least two running instances.
-
-###Increasing memory and disk space
+### Increasing memory and disk space
 
 You can scale an application vertically by increasing the memory or disk space available to each instance of the app.
 


### PR DESCRIPTION
## What

Changed "at least two app instances" to "more than one app instance" so that tenants do not think they just have to run two instances. Also added detail on why they should do this.

## How to review

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Check the content addresses the story https://www.pivotaltracker.com/story/show/153744593

## Who can review

Anyone except Jon Glassman. Dan Carley preferred as he wrote the original story.
