### PR TITLE
[SUPPORT] Added additional metrics

### DIFF
--- a/source/documentation/monitoring_apps/metrics.md
+++ b/source/documentation/monitoring_apps/metrics.md
@@ -4,7 +4,7 @@ Cloud Foundry provides time-series data, or metrics, for each instance of your P
 
 >You can also view data as a one-off snapshot using the Cloud Foundry CLI.
 
-To use the metrics exporter, you deploy it as an app on PaaS. The current metrics supported by the metrics exporter app are CPU, RAM and disk usage data.
+To use the metrics exporter, you deploy it as an app on PaaS. The current metrics supported by the metrics exporter app are CPU, RAM, disk usage data, app crashes, app requests and app response times.
 
 ### Setting up the metrics exporter app
 


### PR DESCRIPTION
## What

Due to changes to the paas-metrics-exporter there are additional 
metrics that were not captured in our documentation. This was reported by a tenant. 

## How to review

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected. No links have been changed.

## Who can review

Not @LeePorte
