### PR TITLE
[Support] Fix the ssh environment instructions

### DIFF
--- a/source/documentation/troubleshooting/ssh.md
+++ b/source/documentation/troubleshooting/ssh.md
@@ -19,11 +19,7 @@ SSH is enabled by default. In most cases, you will find that you can SSH directl
 2. For some tasks to work, you need to set up the interactive SSH session to match the buildpack environment. To do this, run:
 
     ```
-    export DEPS_DIR=/home/vcap/deps
-    export HOME=/home/vcap/app
-    [ -d /home/vcap/profile.d ] && for f in /home/vcap/profile.d/*; do source $f; done
-    [ -d ~/.profile.d ] && for f in ~/.profile.d/*; do source $f; done
-    [ -f ~/.profile ] && source ~/.profile
+    exec /tmp/lifecycle/launcher /home/vcap/app "bash -l" ""
     ```
 
     You need to run this every time you start an SSH session.

--- a/source/documentation/troubleshooting/ssh.md
+++ b/source/documentation/troubleshooting/ssh.md
@@ -21,6 +21,7 @@ SSH is enabled by default. In most cases, you will find that you can SSH directl
     ```
     export DEPS_DIR=/home/vcap/deps
     export HOME=/home/vcap/app
+    [ -d /home/vcap/profile.d ] && for f in /home/vcap/profile.d/*; do source $f; done
     [ -d ~/.profile.d ] && for f in ~/.profile.d/*; do source $f; done
     [ -f ~/.profile ] && source ~/.profile
     ```


### PR DESCRIPTION
## What

With the latest CF upgrade, some of the environment files created by the buildpacks have moved (upstream story - https://www.pivotaltracker.com/n/projects/1042066/stories/151381713).

This PR fixes the instructions to reflect these changes, I've done this as 2 commits:

* The first adds the new directory to the list of ones to check.
* The second changes this entirely to use the launcher command to start a new bash shell with the correct environment setup.

I think it's preferable to use the launcher command as it avoids the need to track changes in upstream.

## How to review

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Check that the new command works and sets up the environment correctly.

## Who can review

Not me.