### PR TITLE
[#143584125] Add link to self-service password reset

### DIFF
--- a/source/documentation/troubleshooting/password.md
+++ b/source/documentation/troubleshooting/password.md
@@ -1,0 +1,5 @@
+## Forgotten passwords
+
+If you believe you have forgotten your GOV.UK PaaS credentials, you can request a password reset using the link below:
+
+[Reset your paswword](https://login.cloud.service.gov.uk/forgot_password)

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -52,3 +52,4 @@ title: "GOV.UK Platform as a Service Technical Documentation"
 <%= partial 'documentation/troubleshooting/postgres' %>
 <%= partial 'documentation/troubleshooting/line-endings' %>
 <%= partial 'documentation/troubleshooting/tracing' %>
+<%= partial 'documentation/troubleshooting/password' %>


### PR DESCRIPTION
# What

We have enabled the self service password reset feature and want to
bring it to the attention of tenants who may be looking for what to do if they have fotgotten their password.

# How to review

* Check it makes sense
* Preview it `bundle exec middleman server` 

## Who can review

not @chrisfarms or @henrytk  