### PR TITLE
Correct typos

### DIFF
--- a/source/documentation/deploying_apps/deploying_django.md
+++ b/source/documentation/deploying_apps/deploying_django.md
@@ -6,7 +6,7 @@ This section explains how to deploy an app using the Django framework. You may a
 
 These steps assume you have already carried out the setup process explained in the [Quick Setup Guide](/#quick-setup-guide) section.
 
-If you are just getting started learning CloudFoundry, you can use the sandbox space by running: ``cf target -s sandbox``
+If you are just getting started learning Cloud Foundry, you can use the sandbox space by running: ``cf target -s sandbox``
 
 1. Put the code for your Django app into a local directory (for example, by checking it out of version control).
 

--- a/source/documentation/deploying_apps/deploying_docker_image.md
+++ b/source/documentation/deploying_apps/deploying_docker_image.md
@@ -36,6 +36,6 @@ Lastly, our support for this functionality has lower priority than usual request
 
 ### Applying security updates
 
-When your app is built with a standard buildpack, you are responsible only for the code of your app. The platform provides both the buildpacks and also a safe and secure root filesystem (`cflinuxfs2`). Buildpack based apps never have root access in their container, which adds another layer of security. We do periodically apply security and funcionality updates to the buildpacks, container root FS and the platform itself.
+When your app is built with a standard buildpack, you are responsible only for the code of your app. The platform provides both the buildpacks and also a safe and secure root filesystem (`cflinuxfs2`). Buildpack based apps never have root access in their container, which adds another layer of security. We do periodically apply security and functionality updates to the buildpacks, container root FS and the platform itself.
 
 When your app is deployed from Docker image, responsibility for the root filesystem and for the complete build of your app shifts to you. You need to ensure proper measures are applied to make your app and root image safe and with the latest security updates. We recommend you use one of the major and well supported linux distributions as your base container. This way you will be able to build an image with latest security patches easily.

--- a/source/documentation/deploying_apps/deploying_rails.md
+++ b/source/documentation/deploying_apps/deploying_rails.md
@@ -133,8 +133,7 @@ to spin up the application. In Rails 4 and below, this will use WEBrick as the w
 server. In Rails 5 and above, the default is
 [puma](http://guides.rubyonrails.org/getting_started.html#starting-up-the-web-server).
 
-You may want to use a different web server in production. See the Cloud Foundry docs for
-[more information on configuring a production server](https://docs.cloudfoundry.org/buildpacks/prod-server.html) [external link].
+You may want to use a different web server in production. See the Cloud Foundry docs for [more information on configuring a production server](https://docs.cloudfoundry.org/buildpacks/prod-server.html) [external link].
 
 
 ### Troubleshooting asset precompilation

--- a/source/documentation/deploying_services/database_services.md
+++ b/source/documentation/deploying_services/database_services.md
@@ -196,7 +196,7 @@ cf update-service postgres PLAN NEW_SERVICE_INSTANCE -c '{"preferred_maintenance
 
 Which essentially would set it to Tuesday morning between 4:00 and 4:30 AM UTC.
 
-For more information about syntax, please reffer to [Amazon RDS Maintenance Documentation](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html#AdjustingTheMaintenanceWindow).
+For more information about syntax, please refer to [Amazon RDS Maintenance Documentation](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html#AdjustingTheMaintenanceWindow).
 
 ### PostgreSQL service backup
 

--- a/source/documentation/getting_started/before_you_start.md
+++ b/source/documentation/getting_started/before_you_start.md
@@ -6,7 +6,7 @@ To be hosted by GOV.UK PaaS, your application must:
 
 * follow the [twelve-factor application](https://12factor.net/) principles (described in more detail below) - this will be the case if your app was written to be deployed to another PaaS like Heroku
 * not carry data at SECRET or above (this is currently out of scope for GOV.UK PaaS)
-* be build using a [supported buildpack](/#buildpacks) or written in one of these languages:
+* be built using a [supported buildpack](/#buildpacks) or written in one of these languages:
     * Go
     * Nodejs
     * Java

--- a/source/documentation/guidance/buildpacks.md
+++ b/source/documentation/guidance/buildpacks.md
@@ -26,7 +26,7 @@ When setting up the app:
 When running the app in production:
 
 - Ensure you have sufficient time to fix issues yourself as using them for deadline-driven development may be risky
-Regularly maintain your buildpack to update your runtime and dependencies as new security vulnerabilities are discovered and fixed
+- Regularly maintain your buildpack to update your runtime and dependencies as new security vulnerabilities are discovered and fixed
 - We may not be able to offer support for P1 or out-of-hours incidents; standard SLAs will not apply
 
 #### Docker images

--- a/source/documentation/guidance/php-database.md
+++ b/source/documentation/guidance/php-database.md
@@ -16,7 +16,7 @@ You should use this method instead of the now-deprecated method of defining PHP 
 
 You can find more information about how to configure the PHP buildpack at the [PHP buildpack configuration documentation](https://docs.cloudfoundry.org/buildpacks/php/gsg-php-config.html) [external link].
 
-Refer to the code below for examples on how to connect your app to MySQL or PostreSQL.
+Refer to the code below for examples on how to connect your app to MySQL or PostgreSQL.
 
 ### Example code - MySQL
 

--- a/source/documentation/troubleshooting/password.md
+++ b/source/documentation/troubleshooting/password.md
@@ -2,4 +2,4 @@
 
 If you believe you have forgotten your GOV.UK PaaS credentials, you can request a password reset using the link below:
 
-[Reset your paswword](https://login.cloud.service.gov.uk/forgot_password)
+[Reset your password](https://login.cloud.service.gov.uk/forgot_password)

--- a/source/documentation/using_ci/travis.md
+++ b/source/documentation/using_ci/travis.md
@@ -1,6 +1,6 @@
 ## Use Travis
 
-*As at April 2017, Cloudfoundry support is currently included in the latest 'edge' version of Travis, which means it will work with GOV.UK PaaS. We expect it will become part of the core product soon. Likewise, our support for this is also new, so please contact our support team with any problems so we can continue to improve our documentation.*
+*As at April 2017, Cloud Foundry support is currently included in the latest 'edge' version of Travis, which means it will work with GOV.UK PaaS. We expect it will become part of the core product soon. Likewise, our support for this is also new, so please contact our support team with any problems so we can continue to improve our documentation.*
 
 In order to do this, you will need to register for a Travis account. If you link this to your GitHub account, it will be able to see all your personal code repositories as well as those of the GitHub organisations you belong to.
 

--- a/source/documentation/using_ci/travis.md
+++ b/source/documentation/using_ci/travis.md
@@ -24,7 +24,7 @@ gem install travis  --no-rdoc --no-ri
 
 ### Automatic setup (recommended for new users)
 
-Run the setup to configure it to work with Cloudfoundry. It will ask for a username and password it can use to login to PaaS, the space and organisation you wish to deploy to, and the API URL. It will encrypt the data for you in `.travis.yml` file.
+Run the setup to configure it to work with Cloud Foundry. It will ask for a username and password it can use to login to PaaS, the space and organisation you wish to deploy to, and the API URL. It will encrypt the data for you in `.travis.yml` file.
 
 ```
 travis setup cloudfoundry
@@ -32,7 +32,7 @@ travis setup cloudfoundry
 
 ### Manual setup
 
-Create `.travis.yml` and put Cloudfoundry configuration in it. If you already have a `.travis.yml` file please add the appropriate lines:
+Create `.travis.yml` and put Cloud Foundry configuration in it. If you already have a `.travis.yml` file please add the appropriate lines:
 
 ```
 deploy:


### PR DESCRIPTION
## What

Correct typos in tech docs:

- Spelling mistakes
- Missing bullet formatting
- Cloudfoundry => Cloud Foundry

## How to review

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Check changes are correct

## Who can review

Anyone except Jon Glassman.
