### PR TITLE
[#154638133] "self-contained" mysql section

### DIFF
--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -127,11 +127,13 @@ We have created the [Conduit](#conduit) plugin to simplify the process of connec
 
 `cf install-plugin conduit`
 
-Once the plugin has finished installing, you can use it by running:
+Once the plugin has finished installing, run the following code in the command line to access an SQL shell for your backing service:
 
-`cf conduit --help`
+`cf conduit SERVICE_NAME -- psql`
 
-Refer to the [Conduit readme file](https://github.com/alphagov/paas-cf-conduit/blob/master/README.md) [external link] for more information on how to use the plugin.
+where `SERVICE_NAME` is a unique descriptive name for this instance of the service.
+
+Run `cf conduit --help` for more options, and refer to the [Conduit readme file](https://github.com/alphagov/paas-cf-conduit/blob/master/README.md) [external link] for more information on how to use the plugin.
 
 ### Upgrade PostgreSQL service plan
 
@@ -149,7 +151,7 @@ cf update-service my-pg-service -p S-HA-dedicated-9.5
 
 The plan upgrade will begin immediately and will usually be completed within about an hour. You can check the status of the change by running the `cf services` command.
 
-You can also [queue a plan upgrade](/#queue-a-migration-postgresql) to happen during a maintenance window to minimise service interruption.
+You can also [queue a plan upgrade](/#queue-a-plan-migration-postgresql) to happen during a maintenance window to minimise service interruption.
 
 Downgrading service plans is not currently supported.
 
@@ -226,18 +228,18 @@ Contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-
 You can set your own maintenance window by running `cf update-service` in the command line and setting the `preferred_maintenance_window` custom parameter:
 
 ```
-cf update-service postgres PLAN SERVICE_NAME -c '{"preferred_maintenance_window": "START_DAY:START_TIME-END_DAY:END_TIME"}'
+cf update-service SERVICE_NAME -c '{"preferred_maintenance_window": "START_DAY:START_TIME-END_DAY:END_TIME"}'
 ```
 
-where `SERVICE_NAME` is a unique, descriptive name for this service instance and `PLAN` is the plan you have, for example:
+where `SERVICE_NAME` is a unique, descriptive name for this service instance, for example:
 
 ```
-cf update-service postgres M-dedicated-9.5 my-pg-service -c '{"preferred_maintenance_window": "Tue:04:00-Tue:04:30"}'
+cf update-service my-pg-service -c '{"preferred_maintenance_window": "Tue:04:00-Tue:04:30"}'
 ```
 
 For more information on maintenance times, refer to the [Amazon RDS Maintenance documentation](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html) [external link].
 
-#### Queue a migration - PostgreSQL
+#### Queue a plan migration - PostgreSQL
 
 Migrating to a new plan may cause interruption to your service instance. To minimise interruption, you can queue the change to begin during a maintenance window by running the following code in the command line:
 
@@ -245,7 +247,7 @@ Migrating to a new plan may cause interruption to your service instance. To mini
 cf update-service postgres SERVICE_NAME -p PLAN -c '{"apply_at_maintenance_window": true, "preferred_maintenance_window": "START_DAY:START_TIME-END_DAY:END_TIME"}'
 ```
 
-where `SERVICE_NAME` is a unique, descriptive name for this service instance and `PLAN` is the plan you want, for example:
+where `SERVICE_NAME` is a unique, descriptive name for this service instance and `PLAN` is the plan that you are upgrading to, for example:
 
 ```
 cf update-service postgres my-pg-service -p S-HA-dedicated-9.5 -c '{"apply_at_maintenance_window": true, "preferred_maintenance_window": "wed:03:32-wed:04:02"}'
@@ -312,7 +314,7 @@ To restore from a snapshot:
   * You can only restore the most recent snapshot from the latest nightly backup
   * You cannot restore from a service instance that has been deleted
   * You must use the same service plan for the copy as for the original service instance
-  * You must create the new service instance in the same organisation and space as the original. This is to prevent unauthorised access to data between spaces. If you need to copy data to a different organisation and/or space, you can use [`pg_dump`](https://www.postgresql.org/docs/9.5/static/backup-dump.html) and [`pg_restore`](https://www.postgresql.org/docs/9.5/static/app-pgrestore.html) via [SSH tunnels](#creating-tcp-tunnels-with-ssh).
+  * You must create the new service instance in the same organisation and space as the original. This is to prevent unauthorised access to data between spaces. If you need to copy data to a different organisation and/or space, you can [connect to your PostgreSQL instance from a local machine using Conduit](/#connect-to-a-postgresql-service-from-your-local-machine).
 
 
 ## MySQL

--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -14,7 +14,9 @@ To set up a PostgreSQL service:
 
 1. Run the following code in the command line to see what plans are available for PostgreSQL:
 
-    `cf marketplace -s postgres`
+    ```
+    cf marketplace -s postgres
+    ```
 
     Here is an example of the output you will see (the exact plans will vary):
 
@@ -39,21 +41,29 @@ To set up a PostgreSQL service:
 
 1. Run the following code in the command line:
 
-    `cf create-service postgres PLAN SERVICE_NAME`
+    ```
+    cf create-service postgres PLAN SERVICE_NAME
+    ```
 
     where `PLAN` is the plan you want, and `SERVICE_NAME` is a unique descriptive name for this instance of the service. For example:
 
-    `cf create-service postgres M-dedicated-9.5 my-pg-service`
+    ```
+    cf create-service postgres M-dedicated-9.5 my-pg-service
+    ```
 
     You should use a high-availability (`HA`) encrypted plan for production apps.
 
 1. It will take between 5 and 10 minutes to set up the service instance. To check its progress, run:
 
-    `cf service SERVICE_NAME`
+    ```
+    cf service SERVICE_NAME
+    ```
 
     for example:
 
-    `cf service my-pg-service`
+    ```
+    cf service my-pg-service
+    ```
 
     The service is set up when the `cf service SERVICE_NAME` command returns a `create succeeded` status. Here is an example of the output you will see:
 
@@ -80,19 +90,27 @@ You must bind your app to the PostgreSQL service to be able to access the databa
 
 1. Run the following code in the command line:
 
-    `cf bind-service APPLICATION SERVICE_NAME`
+    ```
+    cf bind-service APPLICATION SERVICE_NAME
+    ```
 
     where `APPLICATION` is the name of a deployed instance of your application (exactly as specified in your manifest or push command) and `SERVICE_NAME` is a unique descriptive name for this service instance. For example:
 
-    `cf bind-service my-app my-pg-service`
+    ```
+    cf bind-service my-app my-pg-service
+    ```
 
 1. If the app is already running, you should restage the app to make sure it connects:
 
-    `cf restage APPLICATION`
+    ```
+    cf restage APPLICATION
+    ```
 
 1. To confirm that the service is bound to the app, run:
 
-    `cf service SERVICE_NAME`
+    ```
+    cf service SERVICE_NAME
+    ```
 
     and check the `Bound apps:` line of the output.
 
@@ -125,11 +143,15 @@ You must bind your app to the PostgreSQL service to be able to access the databa
 
 We have created the [Conduit](#conduit) plugin to simplify the process of connecting your local machine to a PostgreSQL service. To install this plugin, run the following code from the command line:
 
-`cf install-plugin conduit`
+```
+cf install-plugin conduit
+```
 
 Once the plugin has finished installing, run the following code in the command line to access an SQL shell for your backing service:
 
-`cf conduit SERVICE_NAME -- psql`
+```
+cf conduit SERVICE_NAME -- psql
+```
 
 where `SERVICE_NAME` is a unique descriptive name for this instance of the service.
 
@@ -159,11 +181,15 @@ Downgrading service plans is not currently supported.
 
 You must unbind the PostgreSQL service before you can delete it. To unbind the PostgreSQL service, run the following code in the command line:
 
-`cf unbind-service APPLICATION SERVICE_NAME`
+```
+cf unbind-service APPLICATION SERVICE_NAME
+```
 
 where `APPLICATION` is the name of a deployed instance of your application (exactly as specified in your manifest or push command) and `SERVICE_NAME` is a unique descriptive name for this instance of the service, for example:
 
-`cf unbind-service my-app my-pg-service`
+```
+cf unbind-service my-app my-pg-service
+```
 
 If you unbind your services from your app but do not delete them, the services will persist even after your app is deleted, and you can re-bind or re-connect to them in future.
 
@@ -171,7 +197,9 @@ If you unbind your services from your app but do not delete them, the services w
 
 Once the PostgreSQL service has been unbound from your app, you can delete it. Run the following code in the command line:
 
-`cf delete-service SERVICE_NAME`
+```
+cf delete-service SERVICE_NAME
+```
 
 where `SERVICE_NAME` is a unique descriptive name for this instance of the service.
 
@@ -283,29 +311,41 @@ To restore from a snapshot:
 
  1. Get the global unique identifier (GUID) of the existing instance by running the following code in the command line:
 
-    `cf service SERVICE_NAME --guid`
+    ```
+    cf service SERVICE_NAME --guid
+    ```
 
     where `SERVICE_NAME` is the name of the PostgreSQL service instance you want to copy. For example:
 
-    `cf service my-pg-service --guid`
+    ```
+    cf service my-pg-service --guid
+    ```
 
     This returns a `GUID` in the format `XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX`, for example `32938730-e603-44d6-810e-b4f12d7d109e`.
 
  2. Trigger the creation of a new service based on the snapshot by running:
 
-    `cf create-service postgres PLAN NEW_SERVICE_NAME -c '{"restore_from_latest_snapshot_of": "GUID"}'`
+    ```
+    cf create-service postgres PLAN NEW_SERVICE_NAME -c '{"restore_from_latest_snapshot_of": "GUID"}'
+    ```
 
     where `PLAN` is the plan used in the original instance (you can find this out by running `cf service SERVICE_NAME`), and `NEW_SERVICE_NAME` is a unique, descriptive name for this new instance. For example:
 
-    `cf create-service postgres M-dedicated-9.5 my-pg-service-copy  -c '{"restore_from_latest_snapshot_of": "32938730-e603-44d6-810e-b4f12d7d109e"}'`
+    ```
+    cf create-service postgres M-dedicated-9.5 my-pg-service-copy  -c '{"restore_from_latest_snapshot_of": "32938730-e603-44d6-810e-b4f12d7d109e"}'
+    ```
 
  3. It takes between 5 to 10 minutes for the new service instance to be set up. To find out its status, run:
 
-    `cf service NEW_SERVICE_NAME`
+    ```
+    cf service NEW_SERVICE_NAME
+    ```
 
     for example:
 
-    `cf service my-pg-service-copy`
+    ```
+    cf service my-pg-service-copy
+    ```
 
  4. The new instance is set up when the `cf service NEW_SERVICE_NAME` command returns a `create succeeded` status. See [Set up a PostgreSQL service](#set-up-a-postgresql-service) for more details.
 
@@ -327,7 +367,9 @@ To set up a MySQL service:
 
 1. Run the following code in the command line to see what plans are available for MySQL:
 
-    `cf marketplace -s mysql`
+    ```
+    cf marketplace -s mysql
+    ```
 
     Here is an example of the output you will see (the exact plans will vary):
 
@@ -352,21 +394,29 @@ To set up a MySQL service:
 
 1. Run the following code in the command line:
 
-    `cf create-service mysql PLAN SERVICE_NAME`
+    ```
+    cf create-service mysql PLAN SERVICE_NAME
+    ```
 
     where `PLAN` is the plan you want, and `SERVICE_NAME` is a unique descriptive name for this instance of the service. For example:
 
-    `cf create-service mysql M-dedicated-5.7 my-ms-service`
+    ```
+    cf create-service mysql M-dedicated-5.7 my-ms-service
+    ```
 
     You should use a high-availability (`HA`) encrypted plan for production apps.
 
 1. It will take between 5 and 10 minutes to set up the service instance. To check its progress, run:
 
-    `cf service SERVICE_NAME`
+    ```
+    cf service SERVICE_NAME
+    ```
 
     for example:
 
-    `cf service my-ms-service`
+    ```
+    cf service my-ms-service
+    ```
 
     The service is set up when the `cf service SERVICE_NAME` command returns a `create succeeded` status. Here is an example of the output you will see:
 
@@ -393,19 +443,27 @@ You must bind your app to the MySQL service to be able to access the database fr
 
 1. Run the following code in the command line:
 
-    `cf bind-service APPLICATION SERVICE_NAME`
+    ```
+    cf bind-service APPLICATION SERVICE_NAME
+    ```
 
     where `APPLICATION` is the name of a deployed instance of your application (exactly as specified in your manifest or push command) and `SERVICE_NAME` is a unique descriptive name for this service instance. For example:
 
-    `cf bind-service my-app my-ms-service`
+    ```
+    cf bind-service my-app my-ms-service
+    ```
 
 1. If the app is already running, you should restage the app to make sure it connects:
 
-    `cf restage APPLICATION`
+    ```
+    cf restage APPLICATION
+    ```
 
 1. To confirm that the service is bound to the app, run:
 
-    `cf service SERVICE_NAME`
+    ```
+    cf service SERVICE_NAME
+    ```
 
     and check the `Bound apps:` line of the output.
 
@@ -438,11 +496,15 @@ You must bind your app to the MySQL service to be able to access the database fr
 
 We have created the [Conduit](#conduit) plugin to simplify the process of connecting your local machine to a MySQL service. To install this plugin, run the following code from the command line:
 
-`cf install-plugin conduit`
+```
+cf install-plugin conduit
+```
 
 Once the plugin has finished installing, run the following code in the command line to access an SQL shell for your backing service:
 
-`cf conduit SERVICE_NAME -- mysql`
+```
+cf conduit SERVICE_NAME -- mysql
+```
 
 where `SERVICE_NAME` is a unique descriptive name for this instance of the service.
 
@@ -472,11 +534,15 @@ Downgrading service plans is not currently supported.
 
 You must unbind the MySQL service before you can delete it. To unbind the MySQL service, run the following code in the command line:
 
-`cf unbind-service APPLICATION SERVICE_NAME`
+```
+cf unbind-service APPLICATION SERVICE_NAME
+```
 
 where `APPLICATION` is the name of a deployed instance of your application (exactly as specified in your manifest or push command) and `SERVICE_NAME` is a unique descriptive name for this instance of the service, for example:
 
-`cf unbind-service my-app my-ms-service`
+```
+cf unbind-service my-app my-ms-service
+```
 
 If you unbind your services from your app but do not delete them, the services will persist even after your app is deleted, and you can re-bind or re-connect to them in future.
 
@@ -484,7 +550,9 @@ If you unbind your services from your app but do not delete them, the services w
 
 Once the MySQL service has been unbound from your app, you can delete it. Run the following code in the command line:
 
-`cf delete-service SERVICE_NAME`
+```
+cf delete-service SERVICE_NAME
+```
 
 where `SERVICE_NAME` is a unique descriptive name for this instance of the service.
 

--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -244,13 +244,13 @@ For more information on maintenance times, refer to the [Amazon RDS Maintenance 
 Migrating to a new plan may cause interruption to your service instance. To minimise interruption, you can queue the change to begin during a maintenance window by running the following code in the command line:
 
 ```
-cf update-service postgres SERVICE_NAME -p PLAN -c '{"apply_at_maintenance_window": true, "preferred_maintenance_window": "START_DAY:START_TIME-END_DAY:END_TIME"}'
+cf update-service SERVICE_NAME -p PLAN -c '{"apply_at_maintenance_window": true, "preferred_maintenance_window": "START_DAY:START_TIME-END_DAY:END_TIME"}'
 ```
 
 where `SERVICE_NAME` is a unique, descriptive name for this service instance and `PLAN` is the plan that you are upgrading to, for example:
 
 ```
-cf update-service postgres my-pg-service -p S-HA-dedicated-9.5 -c '{"apply_at_maintenance_window": true, "preferred_maintenance_window": "wed:03:32-wed:04:02"}'
+cf update-service my-pg-service -p S-HA-dedicated-9.5 -c '{"apply_at_maintenance_window": true, "preferred_maintenance_window": "wed:03:32-wed:04:02"}'
 ```
 
 Passing the `preferred_maintenance_window` parameter will alter the default maintenance window for any future maintenance events required for the database instance.
@@ -557,13 +557,13 @@ For more information on maintenance times, refer to the [Amazon RDS Maintenance 
 Migrating to a new plan may cause interruption to your service instance. To minimise interruption, you can queue the change to begin during a maintenance window by running the following code in the command line:
 
 ```
-cf update-service mysql SERVICE_NAME -p PLAN -c '{"apply_at_maintenance_window": true, "preferred_maintenance_window": "START_DAY:START_TIME-END_DAY:END_TIME"}'
+cf update-service SERVICE_NAME -p PLAN -c '{"apply_at_maintenance_window": true, "preferred_maintenance_window": "START_DAY:START_TIME-END_DAY:END_TIME"}'
 ```
 
 where `SERVICE_NAME` is a unique, descriptive name for this service instance and `PLAN` is the plan that you are upgrading to, for example:
 
 ```
-cf update-service mysql my-ms-service -p S-HA-dedicated-5.7 -c '{"apply_at_maintenance_window": true, "preferred_maintenance_window": "wed:03:32-wed:04:02"}'
+cf update-service my-ms-service -p S-HA-dedicated-5.7 -c '{"apply_at_maintenance_window": true, "preferred_maintenance_window": "wed:03:32-wed:04:02"}'
 ```
 
 Passing the `preferred_maintenance_window` parameter will alter the default maintenance window for any future maintenance events required for the database instance.


### PR DESCRIPTION
## What

We are making each of the backing service sections more "self-contained" so that users get a single walkthrough for each backing service.

This change mirrors the previous work done for the PostgreSQL section but for our MySQL section.

## How to review

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).

## Who can review

Not @chrisfarms or @jonathanglassman 
