### PR TITLE
[#154331970] Add shared responsibility model section

### DIFF
--- a/source/documentation/deploying_apps/buildpacks.md
+++ b/source/documentation/deploying_apps/buildpacks.md
@@ -12,7 +12,7 @@ Cloud Foundry uses buildpacks to provide runtime and framework support for appli
 
 We recommend using the standard buildpacks to maximise the support you will receive from GOV.UK PaaS. Using a custom buildpack or Docker image will mean additional setup and maintenance costs.
 
-Your responsibilities change depending on whether you use a standard buildpack, custom buildpack or a docker image. Refer to the [responsibility model guidance](/#responsibility-model) for further information.
+Your responsibilities change depending on whether you use a standard buildpack, custom buildpack or a Docker image. Refer to the [responsibility model guidance](/#responsibility-model) for further information.
 
 ### How to use custom buildpacks
 

--- a/source/documentation/deploying_apps/buildpacks.md
+++ b/source/documentation/deploying_apps/buildpacks.md
@@ -12,7 +12,7 @@ Cloud Foundry uses buildpacks to provide runtime and framework support for appli
 
 We recommend using the standard buildpacks to maximise the support you will receive from GOV.UK PaaS. Using a custom buildpack or Docker image will mean additional setup and maintenance costs.
 
-Refer to the [Guidance](https://docs.cloud.service.gov.uk/#guidance-buildpacks) section for further information on the different options available.
+Your responsibilities change depending on whether you use a standard buildpack, custom buildpack or a docker image. Refer to the [responsibility model guidance](/#responsibility-model) for further information.
 
 ### How to use custom buildpacks
 

--- a/source/documentation/deploying_apps/deploying_docker_image.md
+++ b/source/documentation/deploying_apps/deploying_docker_image.md
@@ -28,7 +28,7 @@ There are a few more specifics about Docker image support in Cloud Foundry:
 * Privileged container mode is not supported. Features depending on this will not work.
 * Only registries that use Docker Registry API V2 are supported.
 
-Your responsibilities change if you use a docker image instead of a buildpack. Refer to the [responsibility model guidance](/#responsibility-model) for further information.
+Your responsibilities change if you use a Docker image instead of a buildpack. Refer to the [responsibility model guidance](/#responsibility-model) for further information.
 
 ### Docker Registry Availability Requirements
 

--- a/source/documentation/deploying_apps/deploying_docker_image.md
+++ b/source/documentation/deploying_apps/deploying_docker_image.md
@@ -28,6 +28,8 @@ There are a few more specifics about Docker image support in Cloud Foundry:
 * Privileged container mode is not supported. Features depending on this will not work.
 * Only registries that use Docker Registry API V2 are supported.
 
+Your responsibilities change if you use a docker image instead of a buildpack. Refer to the [responsibility model guidance](/#responsibility-model) for further information.
+
 ### Docker Registry Availability Requirements
 
 Deploying, scaling, restarting or restaging an app using a Docker image are all dependent on the Docker registry being available, because these actions require pulling the image from the registry.

--- a/source/documentation/guidance/buildpacks.md
+++ b/source/documentation/guidance/buildpacks.md
@@ -45,10 +45,11 @@ Your responsibilities differ depending on whether you use a [standard buildpack]
       </tr>
       <tr>
         <td style="vertical-align: middle; text-align: left">
-          App admin
-          <br> - ensure app instances are up and running
+          App instance lifecycle
+          <br> - ensure app is running
+          <br> - ensure high availability
           <br> - ensure provisioning capacity
-          <br> - stream application logs
+          <br> - stream application logs and metrics
         </td>
         <td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
         <td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
@@ -66,7 +67,7 @@ Your responsibilities differ depending on whether you use a [standard buildpack]
       </tr>
       <tr>
         <td style="vertical-align: middle; text-align: left">
-          Physical hardware
+          Underlying infrastructure
           <br>- resolve hardware failures
           <br>- encrypt network data traffic
         </td>

--- a/source/documentation/guidance/buildpacks.md
+++ b/source/documentation/guidance/buildpacks.md
@@ -1,44 +1,120 @@
 # Guidance
 
-## Buildpacks
+## Responsibility model
+
+Your responsibilities differ depending on whether you use a [standard buildpack](/#buildpacks), [custom buildpack](/#how-to-use-custom-buildpacks) or [Docker image](/#deploy-a-docker-image-experimental) to deploy your app.
+
+<div class="table-container">
+	<table>
+		<tbody>
+			<tr>
+				<th style="vertical-align: middle; text-align: left">Responsibility</th>
+				<th style="vertical-align: middle; text-align: center">Standard Buildpack</th>
+				<th style="vertical-align: middle; text-align: center">Custom Buildpack</th>
+				<th style="vertical-align: middle; text-align: center">Docker Images</th>
+			</tr>
+			<tr>
+				<td style="vertical-align: middle; text-align: left">
+					Your app
+					<br> - apply security updates to app dependencies
+					<br> - run <a href="https://docs.cloud.service.gov.uk/#penetration-testing">pen tests</a>
+				</td>
+				<td style="vertical-align: middle; text-align: center; background-color: #ffbf47">Yours</td>
+				<td style="vertical-align: middle; text-align: center; background-color: #ffbf47">Yours</td>
+				<td style="vertical-align: middle; text-align: center; background-color: #ffbf47">Yours</td>
+			</tr>
+			<tr>
+				<td style="vertical-align: middle; text-align: left">
+					Language / runtime
+					<br> - update language and runtime
+          <br> - provide consistent app build process
+					<br> - monitor and patch runtime vulnerabilities
+				</td>
+				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+				<td style="vertical-align: middle; text-align: center; background-color: #ffbf47">Yours</td>
+				<td style="vertical-align: middle; text-align: center; background-color: #ffbf47">Yours</td>
+			</tr>
+			<tr>
+				<td style="vertical-align: middle; text-align: left">
+					Base operating system
+					<br> - update OS libraries
+				</td>
+				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+				<td style="vertical-align: middle; text-align: center; background-color: #ffbf47">Yours</td>
+			</tr>
+			<tr>
+				<td style="vertical-align: middle; text-align: left">
+					App admin
+					<br> - ensure app instances are up and running
+					<br> - ensure provisioning capacity
+          <br> - stream application logs
+				</td>
+				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+			</tr>
+			<tr>
+				<td style="vertical-align: middle; text-align: left">
+					<a href="https://docs.cloud.service.gov.uk/#deploy-a-backing-or-routing-service">Backing services</a>
+					<br> - maintain service availability
+					<br> - apply security patches
+				</td>
+				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+			</tr>
+			<tr>
+				<td style="vertical-align: middle; text-align: left">
+					Physical hardware
+					<br>- resolve hardware failures
+					<br>- encrypt network data traffic
+				</td>
+				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+			</tr>
+		</tbody>
+	</table>
+</div>
+
+### Standard buildpacks
+
+You are only responsible for the app code and its dependencies. This includes [penetration testing](https://docs.cloud.service.gov.uk/#penetration-testing) your app.
+
 If you're relatively new to cloud or have a small development team, we recommend using the standard buildpacks to maximise the support you will receive from GOV.UK PaaS.
 
-Using a custom buildpack will mean increased development and maintenance responsibilities and costs for you. If your language is not supported by standard buildpacks, we recommend that for a community supported custom buildpack that is maintained and updated by that community. We do not recommend that you create your own buildpack.
+### Custom buildpacks
 
-We are keen to help where we can, so please contact us if you are interested in this feature. If a custom buildpack is requested by multiple tenants, we will look to improving our support in this area.
-
-### Responsibilities
-
-Your responsibilities differ depending on whether you use a standard buildpack, custom buildpack or Docker image to deploy your app.
-
-#### Standard buildpack
-You are only responsible for the app code and its dependencies.
-
-#### Custom buildpacks
-
-You are responsible for managing this custom buildpack as well as the app code and its dependencies. This applies both in setting up the app, and running it in production.
+You are responsible for managing this custom buildpack's language and runtime, as well as the app code and its dependencies. This applies both in setting up the app, and running it in production.
 
 When setting up the app:
 
 - Do your own due diligence on finding a maintained and supported custom buildpack so that you have a community to call upon in the case of problems
-- Test deploying with the buildpack early in your build process, not just before go-live
+- Test deploy with the buildpack early in your build process, not just before go-live
 
 When running the app in production:
 
 - Ensure you have sufficient time to fix issues yourself as using them for deadline-driven development may be risky
 - Regularly maintain your buildpack to update your runtime and dependencies as new security vulnerabilities are discovered and fixed
-- We may not be able to offer support for P1 or out-of-hours incidents; standard SLAs will not apply
+- We may not be able to offer support for P1 or out-of-hours incidents and standard SLAs will not apply
 
-#### Docker images
+Due to these increased responsibilities, we recommend that, if you must use a custom buildpack, you use a community supported one that is maintained and updated by that community. We do not recommend that you create your own buildpack.
+
+Contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) if you are interested in this feature. If a custom buildpack is requested by multiple tenants, we will look to improve our support in this area.
+
+### Docker images
 
 You are responsible for your Docker container and custom image. Learn about this [experimental feature](https://docs.cloud.service.gov.uk/#deploy-a-docker-image-experimental).
+
 
 ### Custom buildpacks compared to Docker images
 
 Custom buildpacks provide some advantages over choosing a Docker solution:
 
+- they provide a standard way of building and staging apps
 - they are not dependent on a Docker registry such as [Docker Hub](https://hub.docker.com/) being available
-- large variety of open source buildpacks, meaning your deployment pipeline doesn’t need to include Docker image creation
+- there is a large variety of open source buildpacks, meaning your deployment pipeline doesn’t need to include Docker image creation
 - buildpacks are designed for 12-factor apps; some Docker images may contain databases or other forms of storage that should be provisioned as an external backing service
 
 Docker images also provide some advantages over custom buildpacks:

--- a/source/documentation/guidance/buildpacks.md
+++ b/source/documentation/guidance/buildpacks.md
@@ -5,77 +5,77 @@
 Your responsibilities differ depending on whether you use a [standard buildpack](/#buildpacks), [custom buildpack](/#how-to-use-custom-buildpacks) or [Docker image](/#deploy-a-docker-image-experimental) to deploy your app.
 
 <div class="table-container">
-	<table>
-		<tbody>
-			<tr>
-				<th style="vertical-align: middle; text-align: left">Responsibility</th>
-				<th style="vertical-align: middle; text-align: center">Standard Buildpack</th>
-				<th style="vertical-align: middle; text-align: center">Custom Buildpack</th>
-				<th style="vertical-align: middle; text-align: center">Docker Images</th>
-			</tr>
-			<tr>
-				<td style="vertical-align: middle; text-align: left">
-					Your app
-					<br> - apply security updates to app dependencies
-					<br> - run <a href="https://docs.cloud.service.gov.uk/#penetration-testing">pen tests</a>
-				</td>
-				<td style="vertical-align: middle; text-align: center; background-color: #ffbf47">Yours</td>
-				<td style="vertical-align: middle; text-align: center; background-color: #ffbf47">Yours</td>
-				<td style="vertical-align: middle; text-align: center; background-color: #ffbf47">Yours</td>
-			</tr>
-			<tr>
-				<td style="vertical-align: middle; text-align: left">
-					Language / runtime
-					<br> - update language and runtime
+  <table>
+    <tbody>
+      <tr>
+        <th style="vertical-align: middle; text-align: left">Responsibility</th>
+        <th style="vertical-align: middle; text-align: center">Standard Buildpack</th>
+        <th style="vertical-align: middle; text-align: center">Custom Buildpack</th>
+        <th style="vertical-align: middle; text-align: center">Docker Images</th>
+      </tr>
+      <tr>
+        <td style="vertical-align: middle; text-align: left">
+          Your app
+          <br> - apply security updates to app dependencies
+          <br> - run <a href="https://docs.cloud.service.gov.uk/#penetration-testing">pen tests</a>
+        </td>
+        <td style="vertical-align: middle; text-align: center; background-color: #ffbf47">Yours</td>
+        <td style="vertical-align: middle; text-align: center; background-color: #ffbf47">Yours</td>
+        <td style="vertical-align: middle; text-align: center; background-color: #ffbf47">Yours</td>
+      </tr>
+      <tr>
+        <td style="vertical-align: middle; text-align: left">
+          Language / runtime
+          <br> - update language and runtime
           <br> - provide consistent app build process
-					<br> - monitor and patch runtime vulnerabilities
-				</td>
-				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
-				<td style="vertical-align: middle; text-align: center; background-color: #ffbf47">Yours</td>
-				<td style="vertical-align: middle; text-align: center; background-color: #ffbf47">Yours</td>
-			</tr>
-			<tr>
-				<td style="vertical-align: middle; text-align: left">
-					Base operating system
-					<br> - update OS libraries
-				</td>
-				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
-				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
-				<td style="vertical-align: middle; text-align: center; background-color: #ffbf47">Yours</td>
-			</tr>
-			<tr>
-				<td style="vertical-align: middle; text-align: left">
-					App admin
-					<br> - ensure app instances are up and running
-					<br> - ensure provisioning capacity
+          <br> - monitor and patch runtime vulnerabilities
+        </td>
+        <td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+        <td style="vertical-align: middle; text-align: center; background-color: #ffbf47">Yours</td>
+        <td style="vertical-align: middle; text-align: center; background-color: #ffbf47">Yours</td>
+      </tr>
+      <tr>
+        <td style="vertical-align: middle; text-align: left">
+          Base operating system
+          <br> - update OS libraries
+        </td>
+        <td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+        <td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+        <td style="vertical-align: middle; text-align: center; background-color: #ffbf47">Yours</td>
+      </tr>
+      <tr>
+        <td style="vertical-align: middle; text-align: left">
+          App admin
+          <br> - ensure app instances are up and running
+          <br> - ensure provisioning capacity
           <br> - stream application logs
-				</td>
-				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
-				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
-				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
-			</tr>
-			<tr>
-				<td style="vertical-align: middle; text-align: left">
-					<a href="https://docs.cloud.service.gov.uk/#deploy-a-backing-or-routing-service">Backing services</a>
-					<br> - maintain service availability
-					<br> - apply security patches
-				</td>
-				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
-				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
-				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
-			</tr>
-			<tr>
-				<td style="vertical-align: middle; text-align: left">
-					Physical hardware
-					<br>- resolve hardware failures
-					<br>- encrypt network data traffic
-				</td>
-				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
-				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
-				<td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
-			</tr>
-		</tbody>
-	</table>
+        </td>
+        <td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+        <td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+        <td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+      </tr>
+      <tr>
+        <td style="vertical-align: middle; text-align: left">
+          <a href="https://docs.cloud.service.gov.uk/#deploy-a-backing-or-routing-service">Backing services</a>
+          <br> - maintain service availability
+          <br> - apply security patches
+        </td>
+        <td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+        <td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+        <td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+      </tr>
+      <tr>
+        <td style="vertical-align: middle; text-align: left">
+          Physical hardware
+          <br>- resolve hardware failures
+          <br>- encrypt network data traffic
+        </td>
+        <td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+        <td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+        <td style="vertical-align: middle; text-align: center; background-color: #2b8cc4">PaaS</td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 
 ### Standard buildpacks

--- a/source/documentation/guidance/buildpacks.md
+++ b/source/documentation/guidance/buildpacks.md
@@ -86,11 +86,11 @@ If you're relatively new to cloud or have a small development team, we recommend
 
 ### Custom buildpacks
 
-You are responsible for managing this custom buildpack's language and runtime, as well as the app code and its dependencies. This applies both in setting up the app, and running it in production.
+You are responsible for managing a custom buildpack's language and runtime, as well as the app code and its dependencies. This applies both to setting up the app, and running it in production.
 
 When setting up the app:
 
-- Do your own due diligence on finding a maintained and supported custom buildpack so that you have a community to call upon in the case of problems
+- Use a buildpack that has been created and is maintained by a community (rather than creating your own buildpack), so that you can ask that community for support with any issues
 - Test deploy with the buildpack early in your build process, not just before go-live
 
 When running the app in production:
@@ -99,9 +99,7 @@ When running the app in production:
 - Regularly maintain your buildpack to update your runtime and dependencies as new security vulnerabilities are discovered and fixed
 - We may not be able to offer support for P1 or out-of-hours incidents and standard SLAs will not apply
 
-Due to these increased responsibilities, we recommend that, if you must use a custom buildpack, you use a community supported one that is maintained and updated by that community. We do not recommend that you create your own buildpack.
-
-Contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) if you are interested in this feature. If a custom buildpack is requested by multiple tenants, we will look to improve our support in this area.
+Contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) if you are interested in this feature. If a custom buildpack is requested by multiple tenants, we will look into improving our support in this area.
 
 ### Docker images
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/154331970

What?
----

We want to document the responsibility model for the users using Docker
on CF vs. using buildpacks. We can write a document inspired on
https://aws.amazon.com/compliance/shared-responsibility-model/,
including a table or image that would list the different layers
of the application, runtime and platform.

We also add links when explaining buildpacks and docker images.

How to review?
--------------

 - Proof reading.
 - Preview it by running the server locally. See Readme for details.

Who?
----
Anyone but @keymon or @jonathanglassman