### PR TITLE
[#155439160] Connect to Redis through Conduit

### DIFF
--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -1065,6 +1065,7 @@ You must:
     options=NO_SSLv2
     options=NO_SSLv3
     foreground=yes
+    pid=/tmp/stunnel.pid
     [redis]
     client = yes
     accept = 127.0.0.1:6379
@@ -1080,7 +1081,7 @@ You must:
 1. Start stunnel by running:
 
     ```
-    sudo stunnel CONFIGURATION_FILE
+    stunnel CONFIGURATION_FILE
     ```
 
 1. Connect to your Redis service instance by running:

--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -1007,13 +1007,13 @@ You must bind your app to the Redis service to be able to access the cache from 
 
 ### Connect to a Redis service instance from your local machine
 
-You must use the [Conduit](#conduit) plugin and stunnel tool to connect your local machine to your Redis service instance.
+We recommend that you use the [Conduit](#conduit) plugin and [stunnel](/#install-and-configure-stunnel) tool to connect your local machine to your Redis service instance. Stunnel is necessary because the Redis command line (CLI) does not support [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security).
 
 #### Prerequisites
 
 You must:
 
-- install the Redis command line (CLI) tool on your local machine (this is included in the [standard Redis installation](https://redis.io/download) [external link])
+- install the Redis CLI tool on your local machine (this is included in the [standard Redis installation](https://redis.io/download) [external link])
 - [log into Cloud Foundry](/#setting-up-the-command-line)
 - [target the space](/#setting-a-target) where your Redis service instance is located
 


### PR DESCRIPTION
## What

Describe how a [PaaS Elasticache Broker](https://github.com/alphagov/paas-elasticache-broker) user can connect to their service instance from their local machine using [Conduit](https://github.com/alphagov/paas-cf-conduit). 

## How to review

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Check the content addresses the story

## Who can review

Anyone except @jonathanglassman and @camelpunch.