### PR TITLE
Clean up backing services part 2

### DIFF
--- a/source/documentation/deploying_services/database_services.md
+++ b/source/documentation/deploying_services/database_services.md
@@ -9,7 +9,3 @@ MongoDB uses replica sets i.e. clusters of MongoDB servers that replicate the co
 ### Elasticsearch
 
 Visit the [Elasticsearch on Compose documentation](https://help.compose.com/docs/elasticsearch-on-compose#section-high-availability-and-failover-details) [external link] to see information about the availability and failover details for the Elasticsearch service.
-
-## TLS connection to MongoDB and Elasticsearch
-
-MongoDB and Elasticsearch use self-signed certificates. In order for your app to verify a TLS connection to these services, the app must use a CA certificate included in a VCAP_SERVICES environment variable.

--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -1190,18 +1190,22 @@ Refer to the [Amazon ElastiCache for Redis page](https://aws.amazon.com/elastica
 
 ## MongoDB
 
-MongoDB is an open source cross-platform document-oriented database program. It uses JSON-like documents with schemas, and is often used for content management such as articles on [GOV.UK](https://www.gov.uk/). This is an early version of the service that is available on request so that we can get feedback, and we will make you aware of any constraints in its use at that time.
+MongoDB is an open source cross-platform document-oriented database program. It uses JSON-like documents with schemas, and is often used for content management such as articles on [GOV.UK](https://www.gov.uk/). This is a private beta trial version of the service that is available on request so that we can get feedback. [Contact the PaaS team](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) to request information on how to enable and use this service for your app, and we will make you aware of any constraints in its use at that time.
+
+### TLS connection to MongoDB
+
+MongoDB uses self-signed certificates. In order for your app to verify a TLS connection to this service, the app must use a CA certificate included in a `VCAP_SERVICES` environment variable.
 
 ## Elasticsearch
 
-Elasticsearch is an open source full text RESTful search and analytics engine that allows you to store and search data. This is an early version of the service that is available on request so that we can get feedback, and we will make you aware of any constraints in its use at that time.
+Elasticsearch is an open source full text RESTful search and analytics engine that allows you to store and search data. This is a private beta trial version of the service that is available on request so that we can get feedback. [Contact the PaaS team](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) to request information on how to enable and use this service for your app, and we will make you aware of any constraints in its use at that time.
 
-## Services
+### TLS connection to Elasticsearch
 
-### User-provided service instance
+Elasticsearch uses self-signed certificates. In order for your app to verify a TLS connection to this service, the app must use a CA certificate included in a VCAP_SERVICES environment variable.
+
+## User-provided services
 
 Cloud Foundry enables tenants to define their own external services that are not available in the marketplace by using a [user-provided service instance](https://docs.cloudfoundry.org/devguide/services/user-provided.html) [external link]. They can be used to deliver service credentials to an application, and/or to trigger streaming of application logs to a syslog compatible consumer. Once created, user-provided service instances behave like service instances created through the marketplace.
-
-### Future services
 
 If you need a particular backing service that we don't yet support, please let us know at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).

--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -1190,7 +1190,7 @@ Refer to the [Amazon ElastiCache for Redis page](https://aws.amazon.com/elastica
 
 ## MongoDB
 
-MongoDB is an open source cross-platform document-oriented database program. It uses JSON-like documents with schemas, and is often used for content management such as articles on [GOV.UK](https://www.gov.uk/). This is a private beta trial version of the service that is available on request so that we can get feedback. [Contact the PaaS team](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) to request information on how to enable and use this service for your app, and we will make you aware of any constraints in its use at that time.
+MongoDB is an open source cross-platform document-oriented database program. It uses JSON-like documents with schemas, and is often used for content management such as articles on [GOV.UK](https://www.gov.uk/). This is a private beta trial version of the service that is available on request so that we can get feedback. This service may not be suitable for everyone, so [contact the PaaS team](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) if you want information on how to enable and use this service for your app. We will make you aware of any constraints in its use at that time.
 
 ### TLS connection to MongoDB
 
@@ -1198,7 +1198,7 @@ MongoDB uses self-signed certificates. In order for your app to verify a TLS con
 
 ## Elasticsearch
 
-Elasticsearch is an open source full text RESTful search and analytics engine that allows you to store and search data. This is a private beta trial version of the service that is available on request so that we can get feedback. [Contact the PaaS team](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) to request information on how to enable and use this service for your app, and we will make you aware of any constraints in its use at that time.
+Elasticsearch is an open source full text RESTful search and analytics engine that allows you to store and search data. This is a private beta trial version of the service that is available on request so that we can get feedback. This service may not be suitable for everyone, so [contact the PaaS team](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) if you want information on how to enable and use this service for your app. We will make you aware of any constraints in its use at that time.
 
 ### TLS connection to Elasticsearch
 


### PR DESCRIPTION
## What

Updates to backing services clean up story as part of the approval process. Added content stating the following:

- MongoDB and ElasticSearch are trial services available on private beta
- Contact the PaaS team to request information and instructions on how to access and use this service for your app
- Moved TLS connection text to MongoDB and ElasticSearch sections
- Updated information architecture on user-provided services

## How to review

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Check that it fulfils requirements discussed on https://www.pivotaltracker.com/story/show/155936172

## Who can review

Anyone except Jon Glassman (preferred Andras)
