### PR TITLE
Remove API outages section

### DIFF
--- a/source/documentation/getting_started/limitations.md
+++ b/source/documentation/getting_started/limitations.md
@@ -1,4 +1,4 @@
-##Limitations
+## Limitations
 
 While GOV.UK PaaS is built using Cloud Foundry technology, we don't support all Cloud Foundry features. This section explains some Cloud Foundry features that are not enabled, as well as some limitations of the beta phase.
 
@@ -22,11 +22,3 @@ Commands known to do this are:
 We are working on a fix to prevent this happening.
 
 In the meantime, we suggest that you use a [blue-green deployment process](https://docs.cloudfoundry.org/devguide/deploy-apps/blue-green.html) [external link], where you have two versions of an app, one that is 'live' and one that is undergoing an update or restart. There are plugins for the Cloud Foundry command line client to facilitate this process. We can recommend the [cf-blue-green-deploy](https://github.com/bluemixgaragelondon/cf-blue-green-deploy) plugin.
-
-### API access may have brief outages during beta
-
-During the beta period, there may be occasional brief periods where API access is unavailable during a platform update, causing commands sent from the command line client to fail. 
-
-If you find that a valid command is failing and the error message does not explain the problem, please wait 5 minutes before trying the command again. If the error persists for more than 5 minutes, it is unlikely to be caused by a platform update and you should contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).  
-
-We are working on a fix to prevent the interruption of API access when we update the platform.


### PR DESCRIPTION
## What

Remove "API access may have brief outages during beta" section. PaaS team did the work required to monitor and remove downtime during deployments.

## How to review

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Check that it addresses https://www.pivotaltracker.com/story/show/155903882

## Who can review

Anyone except Jon Glassman
