### PR TITLE
Correct deleting services section

### DIFF
--- a/source/documentation/deploying_apps/stopping_and_deleting_apps.md
+++ b/source/documentation/deploying_apps/stopping_and_deleting_apps.md
@@ -50,9 +50,9 @@ You must unbind a service instance from any apps it is bound to before you can d
 1. Run `cf services` to see all service instances in your targeted space. You will see the output as per this example:
 
     ```
-    name      service     plan    bound apps    last operation
-    mystuff   service1    small   my-app        create succeeded
-    mydb      service2    large   not-my-app    create succeeded
+    name      service    plan    bound apps    last operation
+    mystuff   postgres   small   my-app        create succeeded
+    mydb      mysql      large   not-my-app    create succeeded
     ```
 
 1. Run the following to unbind a service instance:
@@ -63,7 +63,7 @@ You must unbind a service instance from any apps it is bound to before you can d
     where APPLICATION is the name of a deployed instance of your app (exactly as specified in your manifest or push command) and SERVICE_NAME is a unique descriptive name for this service instance, for example:
 
     ```
-    cf unbind-service my-app service2
+    cf unbind-service my-app mystuff
     ```
 
 1. Run ``cf delete-service SERVICE_NAME`` to delete that service instance.

--- a/source/documentation/deploying_apps/stopping_and_deleting_apps.md
+++ b/source/documentation/deploying_apps/stopping_and_deleting_apps.md
@@ -40,13 +40,30 @@ If you accidentally delete your app without the ``-r`` option, you can delete th
 
 ``cf delete-route [domain name] --hostname [hostname]``
 
-### Deleting services
-Before deleting your app, you will need to delete any services you have provisioned for it.
+### Delete a service instance
 
-You can check the details of these by using the ``cf services`` command to see all active services in the current space. You will be able to see which services are bound *only* to your app - don’t delete services that other apps are also using.
+You must unbind a service instance from any apps it is bound to before you can delete that service instance. Note:
 
-You can then use this information to run
+- you do not need to delete an app's service instances before you can delete that app
+- a service instance can be bound to more than one app 
 
-``cf delete-service [SERVICE INSTANCE]``
+1. Run `cf services` to see all service instances in your targeted space. You will see the output as per this example:
 
-When all services are removed you can then delete your app, as above.
+    ```
+    name      service     plan    bound apps    last operation
+    mystuff   service1    small   my-app        create succeeded
+    mydb      service2    large   not-my-app    create succeeded
+    ```
+
+1. Run the following to unbind a service instance:
+
+    ```
+    cf unbind-service APPLICATION SERVICE_NAME
+    ```
+    where APPLICATION is the name of a deployed instance of your app (exactly as specified in your manifest or push command) and SERVICE_NAME is a unique descriptive name for this service instance, for example:
+
+    ```
+    cf unbind-service my-app service2
+    ```
+
+1. Run ``cf delete-service SERVICE_NAME`` to delete that service instance.


### PR DESCRIPTION
PR re-submitted. Continuation of https://github.com/alphagov/paas-tech-docs/pull/127

What
----

Corrected the Deleting services section of the tech docs to specify:

- you do not need to delete an app's services before you can delete that app
- you should unbind a service instance from the app it is bound to before you delete that service instance

How to review
-----

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Check that the content meets the requirements of story: https://www.pivotaltracker.com/story/show/155065780

Who can review
------

Anyone except Jon Glassman