### PR TITLE
[#154770854] Do not require request to get access to redis

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,10 @@
-## What
+What
+----
 
 Describe what you have changed and why.
 
-## How to review
+How to review
+-------------
 
 Describe the steps required to test the changes.
 
@@ -10,7 +12,8 @@ Describe the steps required to test the changes.
 1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
 1. …
 
-## Who can review
+Who can review
+--------------
 
 Describe who can review the changes. Or more importantly, list the people
 that can't review, because they worked on it.

--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -842,7 +842,7 @@ For more details about how the RDS backup system works, see [Amazon's DB Instanc
 
 ## Redis
 
-Redis is an open source in-memory datastore that can be used as a database cache or message broker. This is a private beta version of the service. Contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) to request access to Redis, and we will make you aware of any constraints.
+Redis is an open source in-memory datastore that can be used as a database cache or message broker.
 
 ### Set up a Redis service
 
@@ -893,12 +893,12 @@ To set up a Redis service:
     ```
     name:            my-redis-service
     service:         redis
-    bound apps:      
-    tags:            
+    bound apps:
+    tags:
     plan:            tiny-clustered
     description:     AWS ElastiCache Redis service
-    documentation:   
-    dashboard:       
+    documentation:
+    dashboard:
 
     Showing status of last operation from service my-redis-service...
 
@@ -949,11 +949,11 @@ You must bind your app to the Redis service to be able to access the cache from 
     name:            my-redis-service
     service:         redis
     bound apps:      my-app
-    tags:            
+    tags:
     plan:            tiny-clustered
     description:     AWS ElastiCache Redis service
-    documentation:   
-    dashboard:       
+    documentation:
+    dashboard:
 
     Showing status of last operation from service testing-time...
 


### PR DESCRIPTION
What
----

Redis is not private beta anymore and it is enabled for everyone
after[1]. It is not required to contact support to get it enabled.

We also fix some spurious trailing whitespaces (my editor did ;))

And we update the github pr template



[1] https://github.com/alphagov/paas-cf/pull/1327

How to review
-------------

Coode review.

Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.

Who can review
--------------

Anyone but @keymon. Maybe @alext