### PR TITLE
Remove MongoDB content

### DIFF
--- a/source/documentation/deploying_services/database_services.md
+++ b/source/documentation/deploying_services/database_services.md
@@ -1,11 +1,1 @@
-## Failover process
 
-### MongoDB
-
-MongoDB uses replica sets i.e. clusters of MongoDB servers that replicate the contents of the master database. Replica sets provide high availability through sharding, a method for distributing data across multiple machines. A shard is a single mongod instance or replica set that stores some portion of a sharded cluster’s total data set. In the standard configuration for MongoDB on our service provider, you get a single-shard with three nodes in a replica-set. Mongo will push all write operations on to the primary data node and then propagate them to the secondary data node on the shard. Should the primary node fail, the secondary will be promoted to primary providing fault-tolerance and redundancy for your databases. The Mongo routers are responsible for dictating any failover, along with load-balancing operations to any of the nodes in the cluster.
-
->Your Mongo instances are backed up automatically, but are not yet directly available to tenants. Please contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) if you need to recover a backup or want to know when related features will be in our roadmap.
-
-### Elasticsearch
-
-Visit the [Elasticsearch on Compose documentation](https://help.compose.com/docs/elasticsearch-on-compose#section-high-availability-and-failover-details) [external link] to see information about the availability and failover details for the Elasticsearch service.

--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -1218,14 +1218,6 @@ Refer to the [Redis LRU cache documentation](https://redis.io/topics/lru-cache) 
 
 Refer to the [Amazon ElastiCache for Redis page](https://aws.amazon.com/elasticache/redis/) [external link] for more information.
 
-## MongoDB
-
-MongoDB is an open source cross-platform document-oriented database program. It uses JSON-like documents with schemas, and is often used for content management such as articles on [GOV.UK](https://www.gov.uk/). This is a private beta trial version of the service that is available on request so that we can get feedback. This service may not be suitable for everyone, so [contact the PaaS team](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) if you want information on how to enable and use this service for your app. We will make you aware of any constraints in its use at that time.
-
-### TLS connection to MongoDB
-
-MongoDB uses self-signed certificates. In order for your app to verify a TLS connection to this service, the app must use a CA certificate included in a `VCAP_SERVICES` environment variable.
-
 ## Elasticsearch
 
 Elasticsearch is an open source full text RESTful search and analytics engine that allows you to store and search data. This is a private beta trial version of the service that is available on request so that we can get feedback. This service may not be suitable for everyone, so [contact the PaaS team](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) if you want information on how to enable and use this service for your app. We will make you aware of any constraints in its use at that time.

--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -1226,6 +1226,10 @@ Elasticsearch is an open source full text RESTful search and analytics engine th
 
 Elasticsearch uses self-signed certificates. In order for your app to verify a TLS connection to this service, the app must use a CA certificate included in a VCAP_SERVICES environment variable.
 
+### Failover process
+
+Visit the [Elasticsearch on Compose documentation](https://help.compose.com/docs/elasticsearch-on-compose#section-high-availability-and-failover-details) [external link] to see information about the availability and failover details for the Elasticsearch service.
+
 ## User-provided services
 
 Cloud Foundry enables tenants to define their own external services that are not available in the marketplace by using a [user-provided service instance](https://docs.cloudfoundry.org/devguide/services/user-provided.html) [external link]. They can be used to deliver service credentials to an application, and/or to trigger streaming of application logs to a syslog compatible consumer. Once created, user-provided service instances behave like service instances created through the marketplace.

--- a/source/documentation/overview/benefits.md
+++ b/source/documentation/overview/benefits.md
@@ -22,7 +22,7 @@ Features of the PaaS platform currently include:
 
 ### Coding in the open
 
-We are making all new GOV.UK PaaS source code open and reusable. You can use our source code if you want to support a different backing service (any networked attached service that your application consumes to do its job, for example a MongoDB instance or a PostgreSQL database).
+We are making all new GOV.UK PaaS source code open and reusable. You can use our source code if you want to support a different backing service (any networked attached service that your application consumes to do its job, for example a PostgreSQL database).
 
 ### Characteristics of GOV.UK PaaS
 This table summarises the core characteristics of the PaaS offering.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -30,7 +30,6 @@ title: "GOV.UK Platform as a Service Technical Documentation"
 <%= partial 'documentation/using_ci/travis' %>
 <%= partial 'documentation/using_ci/jenkins' %>
 <%= partial 'documentation/deploying_services/index' %>
-<%= partial 'documentation/deploying_services/database_services' %>
 <%= partial 'documentation/deploying_services/route_services' %>
 <%= partial 'documentation/deploying_services/use_a_custom_domain' %>
 <%= partial 'documentation/deploying_services/configure_cdn' %>


### PR DESCRIPTION
What
----

- Removed all references to MongoDB backing service
- Moved Elasticsearch failover process content from database_services.md to index.md as this made more sense from an information architecture point of view
- Removed <%= partial 'documentation/deploying_services/database_services' %> from index.html.md.erb as it no longer has any content. The Elasticsearch failover process content has been moved and the MongoDB failover process content has been deleted.

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Check it is fulfils story requirements: https://www.pivotaltracker.com/story/show/157117301

Who can review
--------------

Anyone except Jon Glassman