### PR TITLE
Data official

### DIFF
--- a/source/documentation/deploying_apps/index.md
+++ b/source/documentation/deploying_apps/index.md
@@ -32,6 +32,14 @@ For a production app, you should read the [production checklist](/#production-ch
 * Instances will be restarted if they [exceed memory limits](/#quotas).
 * Your application should write all its log messages to `STDOUT`/`STDERR`, rather than a log file.
 
+## Data security classification
+
+You can store data classified up to "official" on the PaaS.
+
+You cannot store data classified "secret" or "top secret" on the PaaS.
+
+Refer to the [information assurance page](https://www.cloud.service.gov.uk/ia) for information on the assurance process.
+
 ## Secure and non-secure requests
 
 Requests could be made to the non-secure `http://` protocol due to:

--- a/source/documentation/deploying_apps/index.md
+++ b/source/documentation/deploying_apps/index.md
@@ -34,9 +34,9 @@ For a production app, you should read the [production checklist](/#production-ch
 
 ## Data security classification
 
-You can store data classified up to ‘official’ on the PaaS.
+You can store data classified up to ‘official’ on the GOV.UK PaaS.
 
-You cannot store data classified ‘secret‘ or ‘top secret‘ on the PaaS.
+You cannot store data classified ‘secret‘ or ‘top secret‘ on the GOV.UK PaaS.
 
 Refer to the [information assurance page](https://www.cloud.service.gov.uk/ia) for information on the assurance process.
 

--- a/source/documentation/deploying_apps/index.md
+++ b/source/documentation/deploying_apps/index.md
@@ -34,9 +34,9 @@ For a production app, you should read the [production checklist](/#production-ch
 
 ## Data security classification
 
-You can store data classified up to "official" on the PaaS.
+You can store data classified up to ‘official’ on the PaaS.
 
-You cannot store data classified "secret" or "top secret" on the PaaS.
+You cannot store data classified ‘secret‘ or ‘top secret‘ on the PaaS.
 
 Refer to the [information assurance page](https://www.cloud.service.gov.uk/ia) for information on the assurance process.
 

--- a/source/documentation/deploying_apps/index.md
+++ b/source/documentation/deploying_apps/index.md
@@ -40,6 +40,8 @@ You cannot store data classified ‘secret‘ or ‘top secret‘ on the PaaS.
 
 Refer to the [information assurance page](https://www.cloud.service.gov.uk/ia) for information on the assurance process.
 
+Refer to the [GOV.UK page on government security classifications](https://www.gov.uk/government/publications/government-security-classifications) for more information on these classifications.
+
 ## Secure and non-secure requests
 
 Requests could be made to the non-secure `http://` protocol due to:

--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -300,11 +300,13 @@ Type `yes` when asked for confirmation.
 
 ### Data security classification
 
-You can store data classified up to "official" on the PaaS.
+You can store data classified up to ‘official’ on the PaaS.
 
-You cannot store data classified "secret" or "top secret" on the PaaS.
+You cannot store data classified ‘secret‘ or ‘top secret‘ on the PaaS.
 
 Refer to the [information assurance page](https://www.cloud.service.gov.uk/ia) for more information on the assurance process.
+
+Refer to the [GOV.UK page on government security classifications](https://www.gov.uk/government/publications/government-security-classifications) for more information on these classifications.
 
 ### PostgreSQL plans
 
@@ -758,11 +760,13 @@ Type `yes` when asked for confirmation.
 
 ### Data security classification
 
-You can store data classified up to "official" on the PaaS.
+You can store data classified up to ‘official’ on the PaaS.
 
-You cannot store data classified "secret" or "top secret" on the PaaS.
+You cannot store data classified ‘secret‘ or ‘top secret‘ on the PaaS.
 
 Refer to the [information assurance page](https://www.cloud.service.gov.uk/ia) for more information on the assurance process.
+
+Refer to the [GOV.UK page on government security classifications](https://www.gov.uk/government/publications/government-security-classifications) for more information on these classifications.
 
 ### MySQL plans
 
@@ -1248,11 +1252,13 @@ Elasticsearch is an open source full text RESTful search and analytics engine th
 
 ### Data security classification
 
-You can store data classified up to "official" on the PaaS.
+You can store data classified up to ‘official’ on the PaaS.
 
-You cannot store data classified "secret" or "top secret" on the PaaS.
+You cannot store data classified ‘secret‘ or ‘top secret‘ on the PaaS.
 
 Refer to the [information assurance page](https://www.cloud.service.gov.uk/ia) for more information on the assurance process.
+
+Refer to the [GOV.UK page on government security classifications](https://www.gov.uk/government/publications/government-security-classifications) for more information on these classifications.
 
 ### TLS connection to Elasticsearch
 

--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -298,6 +298,14 @@ where `SERVICE_NAME` is a unique descriptive name for this service instance.
 
 Type `yes` when asked for confirmation.
 
+### Data security classification
+
+You can store data classified up to "official" on the PaaS.
+
+You cannot store data classified "secret" or "top secret" on the PaaS.
+
+Refer to the [information assurance page](https://www.cloud.service.gov.uk/ia) for more information on the assurance process.
+
 ### PostgreSQL plans
 
 Each service in the marketplace has multiple plans that vary by availability, storage capacity and encryption.
@@ -748,6 +756,14 @@ where `SERVICE_NAME` is a unique descriptive name for this service instance.
 
 Type `yes` when asked for confirmation.
 
+### Data security classification
+
+You can store data classified up to "official" on the PaaS.
+
+You cannot store data classified "secret" or "top secret" on the PaaS.
+
+Refer to the [information assurance page](https://www.cloud.service.gov.uk/ia) for more information on the assurance process.
+
 ### MySQL plans
 
 Each service in the marketplace has multiple plans that vary by availability, storage capacity and encryption.
@@ -1134,6 +1150,14 @@ where `SERVICE_NAME` is a unique descriptive name for this service instance.
 
 Type `yes` when asked for confirmation.
 
+### Data security classification
+
+You can store data classified up to "official" on the PaaS.
+
+You cannot store data classified "secret" or "top secret" on the PaaS.
+
+Refer to the [information assurance page](https://www.cloud.service.gov.uk/ia) for more information on the assurance process.
+
 ### Redis plans
 
 There are two plans available for the Redis service:
@@ -1221,6 +1245,14 @@ Refer to the [Amazon ElastiCache for Redis page](https://aws.amazon.com/elastica
 ## Elasticsearch
 
 Elasticsearch is an open source full text RESTful search and analytics engine that allows you to store and search data. This is a private beta trial version of the service that is available on request so that we can get feedback. This service may not be suitable for everyone, so [contact the PaaS team](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) if you want information on how to enable and use this service for your app. We will make you aware of any constraints in its use at that time.
+
+### Data security classification
+
+You can store data classified up to "official" on the PaaS.
+
+You cannot store data classified "secret" or "top secret" on the PaaS.
+
+Refer to the [information assurance page](https://www.cloud.service.gov.uk/ia) for more information on the assurance process.
 
 ### TLS connection to Elasticsearch
 

--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -300,9 +300,9 @@ Type `yes` when asked for confirmation.
 
 ### Data security classification
 
-You can store data classified up to ‘official’ on the PaaS.
+You can store data classified up to ‘official’ on the GOV.UK PaaS.
 
-You cannot store data classified ‘secret‘ or ‘top secret‘ on the PaaS.
+You cannot store data classified ‘secret‘ or ‘top secret‘ on the GOV.UK PaaS.
 
 Refer to the [information assurance page](https://www.cloud.service.gov.uk/ia) for more information on the assurance process.
 
@@ -760,9 +760,9 @@ Type `yes` when asked for confirmation.
 
 ### Data security classification
 
-You can store data classified up to ‘official’ on the PaaS.
+You can store data classified up to ‘official’ on the GOV.UK PaaS.
 
-You cannot store data classified ‘secret‘ or ‘top secret‘ on the PaaS.
+You cannot store data classified ‘secret‘ or ‘top secret‘ on the GOV.UK PaaS.
 
 Refer to the [information assurance page](https://www.cloud.service.gov.uk/ia) for more information on the assurance process.
 
@@ -1156,9 +1156,9 @@ Type `yes` when asked for confirmation.
 
 ### Data security classification
 
-You can store data classified up to "official" on the PaaS.
+You can store data classified up to "official" on the GOV.UK PaaS.
 
-You cannot store data classified "secret" or "top secret" on the PaaS.
+You cannot store data classified "secret" or "top secret" on the GOV.UK PaaS.
 
 Refer to the [information assurance page](https://www.cloud.service.gov.uk/ia) for more information on the assurance process.
 
@@ -1252,9 +1252,9 @@ Elasticsearch is an open source full text RESTful search and analytics engine th
 
 ### Data security classification
 
-You can store data classified up to ‘official’ on the PaaS.
+You can store data classified up to ‘official’ on the GOV.UK PaaS.
 
-You cannot store data classified ‘secret‘ or ‘top secret‘ on the PaaS.
+You cannot store data classified ‘secret‘ or ‘top secret‘ on the GOV.UK PaaS.
 
 Refer to the [information assurance page](https://www.cloud.service.gov.uk/ia) for more information on the assurance process.
 

--- a/source/documentation/overview/benefits.md
+++ b/source/documentation/overview/benefits.md
@@ -6,9 +6,9 @@ Your development team can use PaaS to deploy and run government applications wri
 
 PaaS makes user management easy by providing development teams with privilege separation options, for example an ‘admin’ user will be able to assign other team members certain permissions from their PaaS console.
 
-PaaS is deployed to multiple availability zones, making it resilient.
+The GOV.UK PaaS is deployed to multiple availability zones, making it resilient.
 
-PaaS is accredited for information up to ‘official’.
+The GOV.UK PaaS is accredited for information up to ‘official’.
 
 The platform itself is supported 24/7 by GDS, although this does not include application support.
 

--- a/source/documentation/overview/benefits.md
+++ b/source/documentation/overview/benefits.md
@@ -8,7 +8,7 @@ PaaS makes user management easy by providing development teams with privilege se
 
 PaaS is deployed to multiple availability zones, making it resilient.
 
-PaaS is accredited for information up to OFFICIAL.
+PaaS is accredited for information up to ‘official’.
 
 The platform itself is supported 24/7 by GDS, although this does not include application support.
 


### PR DESCRIPTION
What
----

Added data security classification section to the Deploying apps and backing services sections of the tech docs, stating that the PaaS can store data up to "official".

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Check that it covers https://www.pivotaltracker.com/story/show/156810789

Who can review
--------------

Anyone except Lee Porte and Jon Glassman