### PR TITLE
Clarify caching

### DIFF
--- a/source/documentation/deploying_services/use_a_custom_domain.md
+++ b/source/documentation/deploying_services/use_a_custom_domain.md
@@ -1,6 +1,6 @@
 ## Set up a custom domain using the cdn-route service
 
-This section explains how to configure a custom domain name for your application by using our `cdn-route` service to set up a Content Distribution Network (CDN) that will route and [optionally cache](#caching) requests to your app.
+This section explains how to configure a custom domain name for your application by using our `cdn-route` service to set up a Content Distribution Network (CDN) that will route and [cache](#caching) requests to your app.
 
 Using the `cdn-route` service will maximise the support you will receive from GOV.UK PaaS.
 


### PR DESCRIPTION
What
----

Remove "optionally" from "optionally cache" to clarify that caching happens by default.

This will address user feedback that this phrase is potentially misleading.

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Check it fulfils https://www.pivotaltracker.com/story/show/157509104

Who can review
--------------

Anyone excluding Jon Glassman and Andras Ferencz-Szabo
