### PR TITLE
Remove privacy policy

### DIFF
--- a/source/documentation/index.md
+++ b/source/documentation/index.md
@@ -35,7 +35,7 @@ Your department, agency or team must have a GOV.UK PaaS account. This account is
 
 Once your department, agency or team has an org account, you will need an individual account. Ask your [org manager](/#org-manager) to authorise the creation of your individual account.
 
-To provide you with an account, we need to store some personal data about you. Please see our [Privacy Policy](/#privacy-policy) for details.
+To provide you with an account, we need to store some personal data about you. Please see our [privacy notice](https://www.cloud.service.gov.uk/privacy-notice) for details.
 
 Once you have an individual account, you can access the [GOV.UK PaaS admin tool](https://login.cloud.service.gov.uk/login) (requires sign in). This tool allows you to manage your [orgs](/#organisations), [spaces](/#spaces) and [users](/#users-and-user-roles) without using the command line.
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -33,7 +33,6 @@ title: "GOV.UK Platform as a Service Technical Documentation"
 <%= partial 'documentation/monitoring_apps/logs' %>
 <%= partial 'documentation/managing_users/user_accounts' %>
 <%= partial 'documentation/managing_users/user_lifecycle' %>
-<%= partial 'documentation/guidance/privacy' %>
 <%= partial 'documentation/guidance/architecture' %>
 <%= partial 'documentation/guidance/buildpacks' %>
 <%= partial 'documentation/guidance/pentest' %>


### PR DESCRIPTION
What
----

- Removed privacy policy from the PaaS tech docs as the overall privacy policy is a cross-GDS internal facing document, and this does not need to be included in the tech docs as well. 
- Removed link to privacy policy with link to privacy notice.

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).

Who can review
--------------

Lee Porte
