### PR TITLE
Travis ci update

### DIFF
--- a/source/documentation/using_ci/index.md
+++ b/source/documentation/using_ci/index.md
@@ -1,24 +1,26 @@
-# Configuring a custom continuous integration (CI) system
+# Configuring a continuous integration (CI) tool
 
-Setting up a CI service helps you make sure your team are delivering new features without breaking existing functionality. CI will deploy software automatically, but only if the tests pass. This helps you to iterate code faster and with greater confidence, a huge benefit once the codebase becomes larger and more complex.
+A continuous integration (CI) tool deploys software automatically to help you deliver new features without breaking existing functionality.
 
-Tools we have seen used to manage the tests and deployments include Travis, Circle, TeamCity and Jenkins. Detailed instructions on configuring Travis or Jenkins are below.
+Examples of CI tools include [Jenkins](https://jenkins.io/), [Travis](https://travis-ci.com/), [Circle](https://circleci.com/) and [TeamCity](https://www.jetbrains.com/teamcity/) [external links].
 
-- [Travis CI](https://travis-ci.com/) is cloud-based, has a free tier, and is commonly used when a team want to start deploying prototypes from shared GitHub repositories - rather than code running locally on a particular machine. This is equivalent to linking GitHub repositories to Heroku, and takes less than ten minutes. [Set up Travis](#use-travis)
-- [Jenkins](https://jenkins.io/) is more complex, needs detailed technical knowledge, and requires its own infrastructure. [Set up Jenkins](#push-an-app-with-jenkins)
+## Choose CI tool
 
-Security is a key concern when setting up a CI system that interacts with a PaaS. You should protect confidential data and your systems by:
+You should choose a CI tool based on criteria such as:
 
-- running all tests as a [low-privilege PaaS user](/using_ci.html#credentials-for-automated-accounts)
-- not exposing your PaaS credentials publicly; you should store them in encrypted form and decrypt only during runtime.
-- running your tests in a dedicated environment before deploying to production
+- product features
+- support offered
+- pricing
+- security
 
-For security reasons, GOV.UK PaaS will lock your account if your CI system makes multiple failed login attempts in a short period of time. This can happen if you provide incorrect or expired login details. See the [Failed login rate limit](/troubleshooting.html#failed-login-rate-limit) section for more information.
+We recommend you focus on how the tool encrypts and protects any sensitive information or secrets such as keys, usernames or passwords. You are responsible for the assurance of your own services and information. Refer to the [information assurance](https://www.cloud.service.gov.uk/ia) page for more information.
 
-### Credentials for automated accounts
+## Configure your CI tool accounts
 
-In order to avoid developer credentials leaking, particularly those with admin rights, you should request a dedicated PaaS user account for use by your CI service. If you want to deploy to multiple spaces with your CI tool, use a different user account for each. Each user should only have `SpaceDeveloper` access to a single space within your organisation.
+You should request one or more dedicated PaaS user accounts for use by your CI service.
 
-To request a PaaS user account for a CI service, contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) and tell us the email address of the CI user. This should be a unique email address, not already used by another PaaS account. If other people within your team need to be able to reset the password then we recommend that you use a group email address that they also receive the email for.
+Use a different account for each [space](/orgs_spaces_users.html#spaces) you want to deploy to with your CI tool.
 
-We set up user accounts for CI services in the same way as user accounts for people; the accounts have the `SpaceDeveloper` role in the `sandbox` space.
+Each of these accounts should be assigned a [user role](https://docs.cloud.service.gov.uk/orgs_spaces_users.html#users-and-user-roles) with the minimum permissions needed for completing the required CI tool actions.
+
+The GOV.UK PaaS will lock your credentials if your CI tool makes multiple failed login attempts in a short period of time. See the [Failed login rate limit](/troubleshooting.html#failed-login-rate-limit) section for more information.

--- a/source/documentation/using_ci/index.md
+++ b/source/documentation/using_ci/index.md
@@ -2,7 +2,7 @@
 
 A continuous integration (CI) tool deploys software automatically to help you deliver new features without breaking existing functionality.
 
-Examples of CI tools include [Jenkins](https://jenkins.io/), [Travis](https://travis-ci.com/), [Circle](https://circleci.com/) and [TeamCity](https://www.jetbrains.com/teamcity/) [external links].
+Examples of CI tools include [Jenkins](https://jenkins.io/), [Travis](https://travis-ci.com/), [Circle](https://circleci.com/), and [TeamCity](https://www.jetbrains.com/teamcity/) [external links].
 
 ## Choose CI tool
 
@@ -13,14 +13,14 @@ You should choose a CI tool based on criteria such as:
 - pricing
 - security
 
-We recommend you focus on how the tool encrypts and protects any sensitive information or secrets such as keys, usernames or passwords. You are responsible for the assurance of your own services and information. Refer to the [information assurance](https://www.cloud.service.gov.uk/ia) page for more information.
+You should focus on how the tool encrypts and protects any sensitive information or secrets such as keys, usernames or passwords. You are responsible for the [assurance of your own services and information](information assurance](https://www.cloud.service.gov.uk/ia). 
 
 ## Configure your CI tool accounts
 
-You should request one or more dedicated PaaS user accounts for use by your CI service.
+You should request one or more dedicated PaaS user accounts for use by your CI tool.
 
-Use a different account for each [space](/orgs_spaces_users.html#spaces) you want to deploy to with your CI tool.
+Use a different account for each [space](/orgs_spaces_users.html#spaces) you want to deploy your app to using your CI tool.
 
-Each of these accounts should be assigned a [user role](https://docs.cloud.service.gov.uk/orgs_spaces_users.html#users-and-user-roles) with the minimum permissions needed for completing the required CI tool actions.
+Assign a [user role](https://docs.cloud.service.gov.uk/orgs_spaces_users.html#users-and-user-roles) to each of these accounts. These user roles should have the minimum permissions needed for setting up Travis to automatically build and deploy your app.
 
-The GOV.UK PaaS will lock your credentials if your CI tool makes multiple failed login attempts in a short period of time. See the [Failed login rate limit](/troubleshooting.html#failed-login-rate-limit) section for more information.
+The GOV.UK PaaS will lock your credentials if your CI tool makes [multiple failed login attempts in a short period of time](/troubleshooting.html#failed-login-rate-limit). 

--- a/source/documentation/using_ci/travis.md
+++ b/source/documentation/using_ci/travis.md
@@ -1,61 +1,69 @@
-## Use Travis
+## Use the Travis CI tool
 
-*As at April 2017, Cloud Foundry support is currently included in the latest 'edge' version of Travis, which means it will work with GOV.UK PaaS. We expect it will become part of the core product soon. Likewise, our support for this is also new, so please contact our support team with any problems so we can continue to improve our documentation.*
+### Assess Travis
 
-In order to do this, you will need to register for a Travis account. If you link this to your GitHub account, it will be able to see all your personal code repositories as well as those of the GitHub organisations you belong to.
+Before using the Travis CI tool, you should [assess](/using_ci.html#choose-ci-tool) how it encrypts and protects any sensitive information or secrets such as keys, usernames or passwords, and whether it is suitable for your service.
 
-Use the switch icons allow you to turn on the repos Travis will manage - remember that you'll need administrator access on any shared repos. This helps stop you deploying any code you shouldn't!
+### Prerequisites
 
-You will need to know the the particular PaaS `organisation` and `space` you want Travis to deploy your app into. If you don't know, you can get these by logging into PaaS with a terminal window and using the `cf orgs` and `cf spaces` commands.
+Before setting up Travis CI, you must have:
 
-If you haven't already done so, we also strongly recommend that you add a `name` entry to your `manifest.yml` file so that you'll know the address of your app once published. [Find out about names and URLs on PaaS](/deploying_apps.html#names-routes-and-domains).
+- a [Github](https://github.com/) [external link] account
+- admin access to the GitHub repo that hosts your app
+- the latest version of [ruby](https://www.ruby-lang.org/en/downloads/) [external link] installed
+- set your app's [`name`](/deploying_apps.html#names-routes-and-domains) in the app's `manifest.yml` file
 
-### Plan for dedicated CI accounts
+### Set up account
 
-Note that using your own PaaS login details within a CI service should only be a temporary measure. Dedicated user accounts should be set up for testing as soon as reasonably possible - by the end of Alpha at the latest. If you are already an `Org Manager` role on another project in Beta or Live, you should do this anyway. Find out more about [credentials for automated accounts](/using_ci.html#credentials-for-automated-accounts).
+1. Register for a [Travis](https://travis-ci.org) [external link] account.
+1. Link your Travis account to your Github repo.
+1. Select the repos that Travis will manage.
 
-### Download the Travis gem
+### Set up Travis using the gem
 
-Make sure you use at least ruby 1.9.3 and download the gem:
+1. Clone the GitHub repo that hosts your app to your local machine and navigate to the repo folder.
+1. Run `gem install travis  --no-rdoc --no-ri` to download the gem.
+1. Run the following code to set up Travis:
 
-```
-gem install travis  --no-rdoc --no-ri
-```
+    ```
+    travis setup cloudfoundry
+    ```
 
-### Automatic setup (recommended for new users)
+1. Input the following information when asked:
+    - [account](/using_ci.html#configure-your-ci-tool-accounts) username and password
+    - the [space](/orgs_spaces_users.html#spaces) and [organisation](/orgs_spaces_users.html#organisations) to deploy your app to
+    - the API URL: `https://api.cloud.service.gov.uk`
 
-Run the setup to configure it to work with Cloud Foundry. It will ask for a username and password it can use to login to PaaS, the space and organisation you wish to deploy to, and the API URL. It will encrypt the data for you in `.travis.yml` file.
+Travis CI encrypts this information into a `.travis.yml` file.
 
-```
-travis setup cloudfoundry
-```
+You can now [build and deploy the app](using_ci.html#build-and-deploy-the-app).
 
-### Manual setup
+### Set up Travis manually
 
-Create `.travis.yml` and put Cloud Foundry configuration in it. If you already have a `.travis.yml` file please add the appropriate lines:
+1. Clone the GitHub repo that host your app(s) to your local machine and navigate to the repo folder.
+1. Create a `.travis.yml` file.
+1. Add the following code to the `.travis.yml` file:
 
-```
-deploy:
-  edge: true
-  provider: cloudfoundry
-  username: tests@example.com
-  api: https://api.cloud.service.gov.uk
-  organization: mydepartament
-  space: ci
-```
+    ```
+    deploy:
+      edge: true
+      provider: cloudfoundry
+      username: USERNAME
+      api: https://api.cloud.service.gov.uk
+      organization: ORGNAME
+      space: SPACENAME
+    ```
+1. Run the following to write your encrypted credentials to the `.travis.yml`:
 
-Now you can add encrypted credentials to `.travis.yml` with the following command
+    ```
+    travis encrypt --add deploy.password
+    ```
 
-```
-travis encrypt --add deploy.password
-```
+You can now [build and deploy the app](using_ci.html#build-and-deploy-the-app).
 
-### Commit travis.yml to Github
+### Build and deploy the app
 
-Whichever setup approach you took, now commit your code to GitHub. After a few moments, the new `.travis.yml` file will be detected by Travis CI. If you look on the Travis website, you will see it start to automatically build and deploy your application.
+1. Commit the `travis.yml` to GitHub. Travis CI use this file to automatically build and deploy your app.
+1. View your live app at `https://NAME.cloudapps.digital`, where [`NAME`](/deploying_apps.html#names-routes-and-domains)) is the name of your app in the `manifest.yml` file.
 
-### Go to your application
-
-Once Travis has finished building and deploying, go to the URL you set with the `name` field in your `manifest.yml` - the application should be at `https://[name].cloudapps.digital`.
-
-As you continue to develop your prototypes, you can also ask Travis to start running automated tests for you, or deploy to different environments for each branch. More details can be found in the [Travis documentation](https://docs.travis-ci.com/user/gui-and-headless-browsers/).
+For more information on how to use Travis CI, refer to the [Travis CI documentation](https://docs.travis-ci.com) [external link].

--- a/source/documentation/using_ci/travis.md
+++ b/source/documentation/using_ci/travis.md
@@ -1,27 +1,27 @@
-## Use the Travis CI tool
+## Using the Travis CI tool
 
 ### Assess Travis
 
-Before using the Travis CI tool, you should [assess](/using_ci.html#choose-ci-tool) how it encrypts and protects any sensitive information or secrets such as keys, usernames or passwords, and whether it is suitable for your service.
+Before using the Travis CI tool, you should assess how it encrypts and protects any sensitive information or secrets such as keys, usernames or passwords, and whether it is suitable for your service.
 
 ### Prerequisites
 
 Before setting up Travis CI, you must have:
 
 - a [Github](https://github.com/) [external link] account
-- admin access to the GitHub repo that hosts your app
-- the latest version of [ruby](https://www.ruby-lang.org/en/downloads/) [external link] installed
+- admin access to the GitHub repository that hosts your app
+- the latest version of [Ruby](https://www.ruby-lang.org/en/downloads/) [external link] installed
 - set your app's [`name`](/deploying_apps.html#names-routes-and-domains) in the app's `manifest.yml` file
 
 ### Set up account
 
-1. Register for a [Travis](https://travis-ci.org) [external link] account.
+1. Register for a [Travis account](https://travis-ci.org) [external link].
 1. Link your Travis account to your Github repo.
-1. Select the repos that Travis will manage.
+1. Select the repositories you want Travis to manage.
 
 ### Set up Travis using the gem
 
-1. Clone the GitHub repo that hosts your app to your local machine and navigate to the repo folder.
+1. Clone the GitHub repository that hosts your app to your local machine and navigate to the repository folder.
 1. Run `gem install travis  --no-rdoc --no-ri` to download the gem.
 1. Run the following code to set up Travis:
 
@@ -40,7 +40,7 @@ You can now [build and deploy the app](using_ci.html#build-and-deploy-the-app).
 
 ### Set up Travis manually
 
-1. Clone the GitHub repo that host your app(s) to your local machine and navigate to the repo folder.
+1. Clone the GitHub repository that host your app to your local machine and navigate to the repository folder.
 1. Create a `.travis.yml` file.
 1. Add the following code to the `.travis.yml` file:
 
@@ -59,11 +59,11 @@ You can now [build and deploy the app](using_ci.html#build-and-deploy-the-app).
     travis encrypt --add deploy.password
     ```
 
-You can now [build and deploy the app](using_ci.html#build-and-deploy-the-app).
+You can now build and deploy the app.
 
 ### Build and deploy the app
 
-1. Commit the `travis.yml` to GitHub. Travis CI use this file to automatically build and deploy your app.
-1. View your live app at `https://NAME.cloudapps.digital`, where [`NAME`](/deploying_apps.html#names-routes-and-domains)) is the name of your app in the `manifest.yml` file.
+1. Commit the `travis.yml` to GitHub. Travis CI uses this file to automatically build and deploy your app.
+1. View your live app at `https://NAME.cloudapps.digital`, where [`NAME`](/deploying_apps.html#names-routes-and-domains) is the name of your app in the `manifest.yml` file.
 
 For more information on how to use Travis CI, refer to the [Travis CI documentation](https://docs.travis-ci.com) [external link].


### PR DESCRIPTION
What
----
Updated CI section:
- Removed duplicated information
- Brought in line with GDS style
- Added in warning to focus on encryption of sensitive information when choosing a CI tool
Updated Travis section:
- Write active numbered instructions
- Include warning about information encryption

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Check it covers requirements of https://www.pivotaltracker.com/story/show/158791278

Who can review
--------------

Anyone except Jon Glassman or Chris Farmiloe
