### PR TITLE
Drop syslog_msg if it's the same as message field

### DIFF
--- a/source/documentation/monitoring_apps/logs.md
+++ b/source/documentation/monitoring_apps/logs.md
@@ -112,6 +112,12 @@ filter {
             target => "[access][user_agent]"
         }
     }
+
+    if [syslog_msg] == [message] {
+        mutate {
+            remove_field => ["syslog_msg"]
+        }
+    }
 }
 ```
 


### PR DESCRIPTION
What
----

I noticed last week in Kibana that several logs contained the same data in two fields,`syslog_msg` and `message` which was affecting the space required on logit. The effect would be even bigger if taken together with the fact that new versions of elasticsearch index a string field both as a `text` and as `keyword`. ([docs](https://www.elastic.co/blog/strings-are-dead-long-live-strings))

This commit updates the logstash filter so that when all parsing is finished, it will compare the two fields and drop the `syslog_msg` if they are the same.


How to review
-------------

1. Identify that this problem exists on existing stacks
2. Apply the change on that stack's logstash
3. Compare the differences

Who can review
--------------

Not me.
