### PR TITLE
document unencrypted to encrypted postgres migration

### DIFF
--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -279,6 +279,12 @@ You can also [queue a plan upgrade](/deploying_services.html#queue-a-plan-migrat
 
 Downgrading service plans is not currently supported.
 
+Upgrading from an unencrypted to an encrypted service plan using `update-service` is not currently supported. If you wish to do this you will need to:
+
+1. [Set up a PostgreSQL service](/deploying_services.html#set-up-a-postgresql-service) using your desired encrypted plan.
+
+2. Move your data from your unencrypted service to the new encrypted service following the steps described in the [PaaS to PaaS](/deploying_services.html#paas-to-paas) guide.
+
 ### Unbind a PostgreSQL service from your app
 
 You must unbind the PostgreSQL service before you can delete it. To unbind the PostgreSQL service, run the following code in the command line:


### PR DESCRIPTION
What
----

Added documentation for migrating from unencrypted to encrypted postgres service plan, based on recent experience doing this on Registers

How to review
-------------
Following the steps you should be able to migrate from an unencrypted to an encrypted plan. Note: I have not covered handling database downtime or a read-only period after taking a snapshot as I considered those out of scope and they may vary depending on your application.

Who can review
--------------
@46bit or anyone else in PAAS team.