### PR TITLE
Fix broken link to configure your ci tool accounts

### DIFF
--- a/source/documentation/using_ci/jenkins.md
+++ b/source/documentation/using_ci/jenkins.md
@@ -9,7 +9,7 @@ Both approaches require you to set up the credentials plugin first.
 
 ### Set up dedicated accounts
 
-CI systems should not use normal user accounts. Find out more about setting [credentials for automated accounts](/using_ci.html#credentials-for-automated-accounts) in PaaS.
+CI systems should not use normal user accounts. Find out more about [configuring your CI tool accounts](/using_ci.html#configure-your-ci-tool-accounts) in PaaS.
 
 ### Setting up the credentials plugin
 


### PR DESCRIPTION
What
----

Broken link reported in slack here:
https://gds.slack.com/archives/CADHV9267/p1534328991000100

> The link on
> > Find out more about setting credentials for automated accounts in PaaS.
> seems to be broken - is the advice at the moment to just set up another
> user account? there's no special way to set up a CI account at the
> moment?

Looks like this was broken when we renamed the header in 1802ad1e2.


How to review
-------------

Run locally and check the link isn't broken anymore.

Who can review
--------------

Anyone