### PR TITLE
Outdated software buildpacks

### DIFF
--- a/source/documentation/deploying_apps/buildpacks.md
+++ b/source/documentation/deploying_apps/buildpacks.md
@@ -24,11 +24,11 @@ You should tell Cloud Foundry which version of your app's language to use in the
 |Minor|`3.5.x`|
 |Major|`3.x`|
 
-If you specify an exact version, you will need to ensure that you update this version when the GOV.UK PaaS team update the language's buildpack. Check the paas-announce email for information on which language versions are in the latest language buildpacks. If the latest language buildpack does not support the language version your app relies on, your app will fail to start.
+If you specify an exact version, you must update this version when the GOV.UK PaaS team update the language's buildpack. If the latest language buildpack does not support the language version your app relies on, your app will fail to start.
 
-If you specify a major or a minor version, your app will automatically upgrade to use a more recent version of its language when the GOV.UK PaaS team updates the buildpack. The major or minor version must still be live for this upgrade to work. However, if there is a breaking change between language versions, your app may not behave as expected or even fail. You should still check the paas-announce email for information on which language versions are in the latest language buildpack.
+If you specify a major or a minor version, your app will automatically upgrade to use a more recent version of its language when the GOV.UK PaaS team updates the buildpack. The major or minor version must still be live for this upgrade to work. However, if there is a breaking change between language versions, your app may not behave as expected or even fail. 
 
-You should decide if automatically upgrading between language versions instead of specifying an exact version that may be removed is an acceptable risk.
+You should always check the "paas-announce" email for information on which language versions are in the latest language buildpacks.
 
 ### How to use custom buildpacks
 

--- a/source/documentation/deploying_apps/buildpacks.md
+++ b/source/documentation/deploying_apps/buildpacks.md
@@ -16,21 +16,19 @@ Your responsibilities change depending on whether you use a standard buildpack, 
 
 ### Buildpack language version updates
 
-You must tell Cloud Foundry which version of your app's language to use in the buildpack. You can specify an exact, minor or major version of the language. For example:
+You should tell Cloud Foundry which version of your app's language to use in the buildpack. You can specify an exact, minor or major version of the language. For example, with Python:
 
-|Category|Example|
+|Category|Python Example|
 |:---|:---|
 |Exact|`3.5.2`|
 |Minor|`3.5.x`|
 |Major|`3.x`|
 
-If you specify an exact version to use, you will need to ensure that you update this version when the GOV.UK PaaS team update the language's buildpack. Check the paas-announce email for information on which language versions are in the latest language buildpacks.
+If you specify an exact version, you will need to ensure that you update this version when the GOV.UK PaaS team update the language's buildpack. Check the paas-announce email for information on which language versions are in the latest language buildpacks. If the latest language buildpack does not support the language version your app relies on, your app will fail to start.
 
-If the latest language buildpack does not support the language version your app relies on, your app will fail to start.
+If you specify a major or a minor version, your app will automatically upgrade to use a more recent version of its language when the GOV.UK PaaS team updates the buildpack. The major or minor version must still be live for this upgrade to work. However, if there is a breaking change between language versions, your app may not behave as expected or even fail. You should still check the paas-announce email for information on which language versions are in the latest language buildpack.
 
-If you specify a major or a minor version, your app will automatically upgrade to use a more recent version of its language when the GOV.UK PaaS team updates the buildpack.
-
-However, if there is a breaking change between language versions, your app may not behave as expected or even fail. You should still check the paas-announce email for information on which language versions are in the latest language buildpack.
+You should decide if automatically upgrading between language versions instead of specifying an exact version that may be removed is an acceptable risk.
 
 ### How to use custom buildpacks
 

--- a/source/documentation/deploying_apps/buildpacks.md
+++ b/source/documentation/deploying_apps/buildpacks.md
@@ -14,6 +14,24 @@ We recommend using the standard buildpacks to maximise the support you will rece
 
 Your responsibilities change depending on whether you use a standard buildpack, custom buildpack or a Docker image. Refer to the [responsibility model guidance](guidance.html#guidance-2-responsibility-model) for further information.
 
+### Buildpack language version updates
+
+You must tell Cloud Foundry which version of your app's language to use in the buildpack. You can specify an exact, minor or major version of the language. For example:
+
+|Category|Example|
+|:---|:---|
+|Exact|`3.5.2`|
+|Minor|`3.5.x`|
+|Major|`3.x`|
+
+If you specify an exact version to use, you will need to ensure that you update this version when the GOV.UK PaaS team update the language's buildpack. Check the paas-announce email for information on which language versions are in the latest language buildpacks.
+
+If the latest language buildpack does not support the language version your app relies on, your app will fail to start.
+
+If you specify a major or a minor version, your app will automatically upgrade to use a more recent version of its language when the GOV.UK PaaS team updates the buildpack.
+
+However, if there is a breaking change between language versions, your app may not behave as expected or even fail. You should still check the paas-announce email for information on which language versions are in the latest language buildpack.
+
 ### How to use custom buildpacks
 
 There are many application attribute options available when you push an app. You can use the buildpack attribute to specify a custom buildpack for your app through:

--- a/source/documentation/deploying_apps/buildpacks.md
+++ b/source/documentation/deploying_apps/buildpacks.md
@@ -24,11 +24,11 @@ You should tell Cloud Foundry which version of your app's language to use in the
 |Minor|`3.5.x`|
 |Major|`3.x`|
 
-If you specify an exact version, you must update this version when the GOV.UK PaaS team update the language's buildpack. If the latest language buildpack does not support the language version your app relies on, your app will fail to start.
+If you specify an exact version, you must update this version when the GOV.UK PaaS team update the language's buildpack. Your app will fail to start if the language version it relies on is not supported by the latest language buildpack.
 
 If you specify a major or a minor version, your app will automatically upgrade to use a more recent version of its language when the GOV.UK PaaS team updates the buildpack. The major or minor version must still be live for this upgrade to work. However, if there is a breaking change between language versions, your app may not behave as expected or even fail. 
 
-You should always check the "paas-announce" email for information on which language versions are in the latest language buildpacks.
+You should always check the GOV.UK PaaS announcements email for information on which language versions are in the latest language buildpacks.
 
 ### How to use custom buildpacks
 

--- a/source/documentation/deploying_apps/deploying_django.md
+++ b/source/documentation/deploying_apps/deploying_django.md
@@ -8,7 +8,7 @@ Before deploying a Django app, you must:
 
 - log into your [PaaS account](get_started.html#get-an-account)
 - set up the [Cloud Foundry command line](get_started.html#set-up-command-line)
-- [targeted](deploying_apps.html#set-a-target) the appropriate space
+- [target](deploying_apps.html#set-a-target) the appropriate space
 
 1. Put the code for your Django app into a local directory (for example, by checking it out of version control).
 

--- a/source/documentation/deploying_apps/deploying_django.md
+++ b/source/documentation/deploying_apps/deploying_django.md
@@ -19,7 +19,7 @@ Before deploying a Django app, you must:
 
 1. Go to the [Python buildpack page on GitHub](https://github.com/cloudfoundry/python-buildpack/releases) to check which versions of Python are currently included in the Python buildpack.
 
-1. Tell Cloud Foundry which version of Python to use by creating a `runtime.txt` file in the root of the local directory.
+1. Tell Cloud Foundry which version of Python to use by creating a `runtime.txt` file in the root of the local directory. This step is optional.
 
     Refer to the documentation on [buildpack language version updates](deploying_apps.html#buildpack-language-version-updates) for more information.
 

--- a/source/documentation/deploying_apps/deploying_django.md
+++ b/source/documentation/deploying_apps/deploying_django.md
@@ -4,21 +4,26 @@ This section explains how to deploy an app using the Django framework. You may a
 
 > If your app requires a [backing service](/deploying_services.html#deploy-a-backing-or-routing-service), it must be able to work with one of the services supported by PaaS. Instructions for deploying both backing service and non-backing service apps are given in this section.
 
-These steps assume you have already carried out the setup process explained in the [Get started](/get_started.html#get-started) section.
+Before deploying a Django app, you must:
 
-If you are just getting started learning Cloud Foundry, you can use the sandbox space by running: ``cf target -s sandbox``
+- log into your [PaaS account](get_started.html#get-an-account)
+- set up the [Cloud Foundry command line](get_started.html#set-up-command-line)
+- [targeted](deploying_apps.html#set-a-target) the appropriate space
 
 1. Put the code for your Django app into a local directory (for example, by checking it out of version control).
 
-2. If you are using Git, add `*.pyc` and `local_settings.py` to your `.gitignore`, file, then
+1. If you are using Git, add `*.pyc` and `local_settings.py` to your `.gitignore` file, then
    [exclude files ignored by Git](/deploying_apps.html#excluding-files) so Cloud Foundry will ignore them too.
 
-3. Tell Cloud Foundry which Python runtime to use by creating a `runtime.txt`   file in the root of the local folder. The contents of the file should  
-   be:
+1. Run `cf buildpacks` in the command line to check the version of the Python buildpack.
 
-        python-3.5.1  
+1. Go to the [Python buildpack page on GitHub](https://github.com/cloudfoundry/python-buildpack/releases) to check which versions of Python are currently included in the Python buildpack.
 
-    replacing "3.5.1" with the version of Python you want to use (it must be supported by the buildpack: currently versions 2.7.11 to 3.5.2 are supported.)
+1. Tell Cloud Foundry which version of Python to use by creating a `runtime.txt` file in the root of the local directory.
+
+    Refer to the documentation on [buildpack language version updates](deploying_apps.html#buildpack-language-version-updates) for more information.
+
+    Refer to the Cloud Foundry documentation for more information on how to [specify a Python version](https://docs.cloudfoundry.org/buildpacks/python/index.html#runtime) [external link].
 
 4. Make sure you have all the required modules for your project installed into your virtual environment (including Django).
 

--- a/source/documentation/deploying_apps/deploying_java.md
+++ b/source/documentation/deploying_apps/deploying_java.md
@@ -106,7 +106,7 @@ For more configuration options see [Tomcat Container](https://github.com/cloudfo
 
 ### Specify a Java version
 
-You must tell Cloud Foundry which version of Java your app uses in the Java buildpack.
+You should tell Cloud Foundry which version of Java your app uses in the Java buildpack.
 
 Refer to the documentation on [buildpack language version updates](deploying_apps.html#buildpack-language-version-updates) for more information.
 

--- a/source/documentation/deploying_apps/deploying_java.md
+++ b/source/documentation/deploying_apps/deploying_java.md
@@ -104,6 +104,14 @@ Note that you do **not** need to deploy Tomcat along with your application. The 
 
 For more configuration options see [Tomcat Container](https://github.com/cloudfoundry/java-buildpack/blob/master/docs/container-tomcat.md) [external link].
 
+### Specify a Java version
+
+You must tell Cloud Foundry which version of Java your app uses in the Java buildpack.
+
+Refer to the documentation on [buildpack language version updates](deploying_apps.html#buildpack-language-version-updates) for more information.
+
+Refer to the Cloud Foundry OpenJDK JRE documentation for more information on [the Java buildpack](https://github.com/cloudfoundry/java-buildpack/blob/master/docs/jre-open_jdk_jre.md) [external link].
+
 ### Deploying other JVM-based applications
 
 The Java buildpack supports running any JVM-based applications (such as Scala, Clojure etc.) with little or zero additional configuration. For detailed examples of deploying applications using other frameworks and JVM-based languages:

--- a/source/documentation/deploying_apps/deploying_node_js.md
+++ b/source/documentation/deploying_apps/deploying_node_js.md
@@ -112,7 +112,7 @@ You should also remember to include dependencies for any service bindings in ``p
 
 ### Specify a Node.js version
 
-You must tell Cloud Foundry which version of Node.js your app uses in the Node.js buildpack.
+You should tell Cloud Foundry which version of Node.js your app uses in the Node.js buildpack.
 
 Refer to the documentation on [buildpack language version updates](deploying_apps.html#buildpack-language-version-updates) for more information.
 

--- a/source/documentation/deploying_apps/deploying_node_js.md
+++ b/source/documentation/deploying_apps/deploying_node_js.md
@@ -109,3 +109,11 @@ You should also remember to include dependencies for any service bindings in ``p
         // ...
       }
     }
+
+### Specify a Node.js version
+
+You must tell Cloud Foundry which version of Node.js your app uses in the Node.js buildpack.
+
+Refer to the documentation on [buildpack language version updates](deploying_apps.html#buildpack-language-version-updates) for more information.
+
+Refer to the Cloud Foundry documentation for more information on how to [specify a Node.js version](https://docs.cloudfoundry.org/buildpacks/node/index.html#runtime) [external link].

--- a/source/documentation/deploying_apps/deploying_rails.md
+++ b/source/documentation/deploying_apps/deploying_rails.md
@@ -126,6 +126,14 @@ These instructions are for deploying a Rails app with a PostgreSQL database, and
 
 Your app should now be available at `https://APPNAME.cloudapps.digital.` For a production app, you should read the [production checklist](/deploying_apps.html#production-checklist).
 
+### Specify a Ruby version
+
+You must tell Cloud Foundry which version of Ruby your app uses in the Ruby buildpack.
+
+Refer to the documentation on [buildpack language version updates](deploying_apps.html#buildpack-language-version-updates) for more information.
+
+Refer to the Cloud Foundry documentation for more information on how to [specify a Ruby version](https://docs.cloudfoundry.org/buildpacks/ruby/index.html#runtime) [external link].
+
 ### Web servers
 
 By default, the Cloud Foundry Ruby buildpack [runs `bin/rails server`](https://github.com/cloudfoundry/ruby-buildpack/blob/1f0ac3ce10866390d161c3f27e71d64890859454/lib/language_pack/rails4.rb#L27)

--- a/source/documentation/deploying_apps/deploying_rails.md
+++ b/source/documentation/deploying_apps/deploying_rails.md
@@ -128,7 +128,7 @@ Your app should now be available at `https://APPNAME.cloudapps.digital.` For a p
 
 ### Specify a Ruby version
 
-You must tell Cloud Foundry which version of Ruby your app uses in the Ruby buildpack.
+You should tell Cloud Foundry which version of Ruby your app uses in the Ruby buildpack.
 
 Refer to the documentation on [buildpack language version updates](deploying_apps.html#buildpack-language-version-updates) for more information.
 


### PR DESCRIPTION
What
----
- Removed references to outdated software in Python buildpack
- Tweaked Python content to be more active
- Created new section on software versions in buildpacks
- Created new section for each app referring to other new section, with links to cloud foundry docs as required

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Check it fulfils story: https://www.pivotaltracker.com/story/show/160099400

Who can review
--------------

Anyone except Jon Glassman or Sam Crang
