### PR TITLE
Add manifest method to backing service tech docs

### DIFF
--- a/source/documentation/deploying_apps/env_variables.md
+++ b/source/documentation/deploying_apps/env_variables.md
@@ -5,11 +5,11 @@ You must store all configuration information for your app as environment variabl
 This could include:
 
 - credentials for external services that your app uses, for example a Twitter account
-- values that will vary with each deployment of the app, for example the canonical URL.
+- values that will vary with each deployment of the app, for example the canonical URL
 
-To view an app's current environment variables, run `cf env APPNAME`.
+To view an app's current environment variables, run `cf env APP_NAME`.
 
-To create or update a variable, run `cf set-env APPNAME ENV_VAR_NAME ENV_VAR_VALUE`.
+To create or update a variable, run `cf set-env APP_NAME ENV_VAR_NAME ENV_VAR_VALUE`.
 
 If you're deploying a pre-existing app written in line with 12-factor principles, you should check the app's documentation for any environment variables you need to set.
 
@@ -22,7 +22,7 @@ heroku config:set VARIABLE=value
 then you should run the equivalent command using `cf set-env`:
 
 ```
-cf set-env APPNAME VARIABLE value
+cf set-env APP_NAME VARIABLE value
 ```
 
 ### System-provided environment variables
@@ -33,7 +33,7 @@ System-provided variables tell you about configuration details handled by the Pa
 - the maximum memory each instance can use
 - the external IP address of the instance
 
-Do not attempt to change the values of these system-provided variables with the CLI or your app's code.
+Do not attempt to change the values of these system-provided variables.
 
 Refer to the [Cloud Foundry Environment Variables documentation](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html) [external link] for a full list of variables.
 

--- a/source/documentation/deploying_apps/env_variables.md
+++ b/source/documentation/deploying_apps/env_variables.md
@@ -9,9 +9,13 @@ This could include:
 
 To view an app's current environment variables, run `cf env APP_NAME`.
 
-To create or update a variable, run `cf set-env APP_NAME ENV_VAR_NAME ENV_VAR_VALUE`.
+To create or update a variable, run the following:
 
-If you're deploying a pre-existing app written in line with 12-factor principles, you should check the app's documentation for any environment variables you need to set.
+```
+cf set-env APP_NAME ENV_VAR_NAME ENV_VAR_VALUE`
+```
+
+If you're deploying a pre-existing app, you should check the app's documentation for any environment variables you need to set.
 
 For example, if the app has these instructions for deploying to Heroku:
 
@@ -27,21 +31,19 @@ cf set-env APP_NAME VARIABLE value
 
 ### System-provided environment variables
 
-System-provided variables tell you about configuration details handled by the PaaS, for example:
+System-provided environment variables tell you about configuration details handled by the PaaS, for example:
 
-- the port on which the application is listening 
-- the maximum memory each instance can use
-- the external IP address of the instance
+- the port on which the app is listening 
+- the maximum memory each app instance can use
+- the external IP address of the app instance
 
-Do not attempt to change the values of these system-provided variables.
-
-Refer to the [Cloud Foundry Environment Variables documentation](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html) [external link] for a full list of variables.
+Do not attempt to change the values of these system-provided variables using the command line or your app's code.
 
 `VCAP_SERVICES` and `VCAP_APPLICATION` are two important variables for initial setup:
 
-- `VCAP_SERVICES` contains details, including credentials, of any backing services bound to the app.
+- `VCAP_SERVICES` contains details, including credentials, of any backing services bound to the app
 
-- `VCAP_APPLICATION` provides details of the currently running application, for example the language runtime version.
+- `VCAP_APPLICATION` provides details of the currently running application, for example the language runtime version
 
 To see the values of the system-provided variables, run `cf env APP_NAME`.
 
@@ -82,3 +84,5 @@ Here is an example of the structure of the information contained in `VCAP_SERVIC
  }
 }
 ```
+
+Refer to the [Cloud Foundry Environment Variables documentation](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html) [external link] for a full list of environment variables.

--- a/source/documentation/deploying_apps/env_variables.md
+++ b/source/documentation/deploying_apps/env_variables.md
@@ -1,45 +1,53 @@
 ## Environment variables
 
-All the configuration information for your app must be stored as environment variables, not in the code. 
+You must store all configuration information for your app as environment variables. 
 
-This includes credentials for external services that your app uses, such as a Twitter account, as well as values that will vary with each deployment of the app, like the canonical URL.
+This could include:
 
-To view an app's current environment variables, run:
+- credentials for external services that your app uses, for example a Twitter account
+- values that will vary with each deployment of the app, for example the canonical URL.
 
-``cf env APPNAME``
+To view an app's current environment variables, run `cf env APPNAME`.
 
-To create or update a variable, use:
+To create or update a variable, run `cf set-env APPNAME ENV_VAR_NAME ENV_VAR_VALUE`.
 
-``cf set-env APPNAME ENV_VAR_NAME ENV_VAR_VALUE``
+If you're deploying a pre-existing app written in line with 12-factor principles, you should check the app's documentation for any environment variables you need to set.
 
-If you're deploying a pre-existing app that was written with 12-factor in mind, check the app's documentation for any environment variables you need to set.
+For example, if the app has these instructions for deploying to Heroku:
 
-If the app has instructions to deploy to Heroku, and tells you to do something like:
+```
+heroku config:set VARIABLE=value
+```
 
-``heroku config:set VARIABLE=value``
+then you should run the equivalent command using `cf set-env`:
 
-then you should do the equivalent command with ``cf set-env``:
-
-``cf set-env APPNAME VARIABLE value``
+```
+cf set-env APPNAME VARIABLE value
+```
 
 ### System-provided environment variables
 
-As well as environment variables you set yourself, there are a number of system-provided variables which give you information about configuration details handled by the PaaS: the port on which the application is listening, the maximum memory each instance can use, the external IP address of the instance, and so on.
+System-provided variables tell you about configuration details handled by the PaaS, for example:
+
+- the port on which the application is listening 
+- the maximum memory each instance can use
+- the external IP address of the instance
 
 Do not attempt to change the values of these system-provided variables with the CLI or your app's code.
 
-For a full list, see Cloud Foundry's [Cloud Foundry Environment Variables](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html) [external link] documentation.
+Refer to the [Cloud Foundry Environment Variables documentation](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html) [external link] for a full list of variables.
 
-Two important variables for initial setup are:
+`VCAP_SERVICES` and `VCAP_APPLICATION` are two important variables for initial setup:
 
-* `VCAP_SERVICES` contains details (including credentials) of any backing services bound to the app
-* `VCAP_APPLICATION` provides details of the currently running application (for example, language runtime version)
+- `VCAP_SERVICES` contains details, including credentials, of any backing services bound to the app.
 
-To see the values of the system-provided variables, run `cf env APPNAME`.
+- `VCAP_APPLICATION` provides details of the currently running application, for example the language runtime version.
 
-If your app connects to a backing service, you may need to have it parse `VCAP_SERVICES` to get the credentials and other settings relating to that service and set the appropriate environment variables.
+To see the values of the system-provided variables, run `cf env APP_NAME`.
 
-However, some buildpacks will do this for you automatically. See the deploy instructions for the language/framework you are using for details.
+If your app connects to a backing service, you may need to have your app parse `VCAP_SERVICES` to get the credentials and other settings relating to that service and set the appropriate environment variables.
+
+Some buildpacks will do this for you automatically. Refer to the deploy instructions for the language or framework you are using for more information.
 
 Here is an example of the structure of the information contained in `VCAP_SERVICES`:
 

--- a/source/documentation/deploying_apps/env_variables.md
+++ b/source/documentation/deploying_apps/env_variables.md
@@ -22,7 +22,7 @@ then you should do the equivalent command with ``cf set-env``:
 
 ``cf set-env APPNAME VARIABLE value``
 
-###System-provided environment variables
+### System-provided environment variables
 
 As well as environment variables you set yourself, there are a number of system-provided variables which give you information about configuration details handled by the PaaS: the port on which the application is listening, the maximum memory each instance can use, the external IP address of the instance, and so on.
 
@@ -32,15 +32,45 @@ For a full list, see Cloud Foundry's [Cloud Foundry Environment Variables](https
 
 Two important variables for initial setup are:
 
-* VCAP_SERVICES contains details (including credentials) of any backing services bound to the app
-* VCAP_APPLICATION provides details of the currently running application (for example, language runtime version)
+* `VCAP_SERVICES` contains details (including credentials) of any backing services bound to the app
+* `VCAP_APPLICATION` provides details of the currently running application (for example, language runtime version)
 
-To see the values of the system-provided variables, use:
+To see the values of the system-provided variables, run `cf env APPNAME`.
 
-``cf env APPNAME``
-
-If your app connects to a backing service, you may need to have it parse VCAP_SERVICES to get the credentials and other settings relating to that service and set the appropriate environment variables.
+If your app connects to a backing service, you may need to have it parse `VCAP_SERVICES` to get the credentials and other settings relating to that service and set the appropriate environment variables.
 
 However, some buildpacks will do this for you automatically. See the deploy instructions for the language/framework you are using for details.
 
+Here is an example of the structure of the information contained in `VCAP_SERVICES`:
 
+```
+{
+ "VCAP_SERVICES": {
+  "postgres": [
+   {
+    "binding_name": null,
+    "credentials": {
+     "host": "rdsbroker-66ecd739-2e98-401a-9e45-15436165be06.c7uewwm9qebj.eu-west-1.rds.amazonaws.com",
+     "jdbcuri": "jdbc:postgresql://rdsbroker-66ecd739-2e98-401a-9e45-17938165be06.c7uewwm9qebj.eu-west-1.rds.amazonaws.com:5432/DATABASE_NAME?password=PASSWORD\u0026ssl=true\u0026user=USERNAME",
+     "name": "DATABASE_NAME",
+     "password": "PASSWORD",
+     "port": 5432,
+     "uri": "postgres://USERNAME:PASSWORD@rdsbroker-66ecd739-2e98-401a-9e45-17938165be06.c7uewwm9qebj.eu-west-1.rds.amazonaws.com:5432/DATABASE_NAME",
+     "username": "USERNAME"
+    },
+    "instance_name": "SERVICE_NAME",
+    "label": "postgres",
+    "name": "SERVICE_NAME",
+    "plan": "PLAN",
+    "provider": null,
+    "syslog_drain_url": null,
+    "tags": [
+     "postgres",
+     "relational"
+    ],
+    "volume_mounts": []
+   }
+  ]
+ }
+}
+```

--- a/source/documentation/deploying_apps/index.md
+++ b/source/documentation/deploying_apps/index.md
@@ -2,17 +2,19 @@
 
 ## Deployment overview
 
-The `cf push` command is used both to create a new app and to push a new version of an existing one. The basic steps:
+The `cf push` command is used to both create a new app and to push a new version of an existing app.
 
-1. Put your app's code in a directory. This is usually accomplished by checking it out of version control.
+1. Put your app's code and configuration files in a local directory.
 
-1. [Target](deploying_apps.html#set-a-target) the appropriate organisation and space.
+1. [Target](deploying_apps.html#set-a-target) the appropriate organisation and space by running:
 
     ```
     cf target -o ORG_NAME -s SPACE_NAME
     ```
+    
+    where `ORG_NAME` is the name of the org, and `SPACE_NAME` is the name of the space.
 
-1. Create a `manifest.yml` file in the same directory as your app's code. The manifest file tells Cloud Foundry what to do with your app.
+1. Create a `manifest.yml` file in the same local directory as your app's code. The manifest file tells Cloud Foundry what to do with your app. An exmaple manifest:
 
     ```
     ---
@@ -22,13 +24,13 @@ The `cf push` command is used both to create a new app and to push a new version
 
     where `APP_NAME` is the unique name for your app. You can run `cf apps` to see apps which already exist.
 
-1. In the directory which contains your app's code, configuration files, and manifest, deploy the app by running `cf push`.
+1. Deploy your app by running `cf push` in the directory which contains your app's code, configuration files, and manifest.
 
 Your app should now be live at `https://APP_NAME.cloudapps.digital`.
 
-There are many options available when you deploy an app. See the Cloud Foundry documentation on [Deploying with Application Manifests](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) [external link] for details.
+Refer to the Cloud Foundry documentation on [Deploying with Application Manifests](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) [external link] for more information on the options available when you deploy an app.
 
-For a production app, you should read the [production checklist](deploying_apps.html#production-checklist).
+Refer to the [production checklist](deploying_apps.html#production-checklist) if your app is a production app.
 
 ### Set a target
 
@@ -42,9 +44,9 @@ cf target -o ORG_NAME -s SPACE_NAME
 
 where `ORG_NAME` is the name of the org, and `SPACE_NAME` is the name of the space.
 
-Once you set the target, the Cloud Foundry client remembers it until you change it.
+The Cloud Foundry client remembers the target until you change it.
 
-You can change space without changing org using:
+You can change space without changing org by running:
 
 ```
 cf target -s SPACE_NAME

--- a/source/documentation/deploying_apps/index.md
+++ b/source/documentation/deploying_apps/index.md
@@ -2,7 +2,7 @@
 
 ## Deployment overview
 
-The `cf push` command is used to both create a new app and to push a new version of an existing app.
+The `cf push` command can both create a new app and push a new version of an existing app.
 
 1. Put your app's code and configuration files in a local directory.
 
@@ -14,7 +14,7 @@ The `cf push` command is used to both create a new app and to push a new version
     
     where `ORG_NAME` is the name of the org, and `SPACE_NAME` is the name of the space.
 
-1. Create a `manifest.yml` file in the same local directory as your app's code. The manifest file tells Cloud Foundry what to do with your app. An exmaple manifest:
+1. Create a `manifest.yml` file in the same local directory as your app's code. The manifest file tells Cloud Foundry what to do with your app. An example manifest:
 
     ```
     ---

--- a/source/documentation/deploying_apps/index.md
+++ b/source/documentation/deploying_apps/index.md
@@ -4,25 +4,29 @@
 
 The `cf push` command is used both to create a new app and to push a new version of an existing one. The basic steps:
 
-1. Put the code you want to deploy in a directory. This is usually accomplished by checking it out of version control.
+1. Put your app's code in a directory. This is usually accomplished by checking it out of version control.
 
 1. [Target](deploying_apps.html#set-a-target) the appropriate organisation and space.
 
     ```
-    cf target -o SOMEORG -s SOMESPACE
+    cf target -o ORG_NAME -s SPACE_NAME
     ```
 
-1. Deploy the application by running:
+1. Create a `manifest.yml` file in the same directory as your app's code. The manifest file tells Cloud Foundry what to do with your app.
 
     ```
-    cf push APPNAME
+    ---
+    applications:
+    - name: APP_NAME
     ```
 
-    from the directory which contains the code and configuration files for your app.
+    where `APP_NAME` is the unique name for your app. You can run `cf apps` to see apps which already exist.
 
-The app should now be live at `https://APPNAME.cloudapps.digital`.
+1. In the directory which contains your app's code, configuration files, and manifest, deploy the app by running `cf push`.
 
-There are many options available when you ``push`` an app. You can optionally set them in a ``manifest.yml`` file in the directory from which you are running the ``push`` command. See the Cloud Foundry documentation on [Deploying with Application Manifests](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) [external link] for details.
+Your app should now be live at `https://APP_NAME.cloudapps.digital`.
+
+There are many options available when you deploy an app. See the Cloud Foundry documentation on [Deploying with Application Manifests](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) [external link] for details.
 
 For a production app, you should read the [production checklist](deploying_apps.html#production-checklist).
 
@@ -33,17 +37,17 @@ To deploy an app, you need to set a target. A target is a combination of an org 
 Run the following to set the target:
 
 ```
-cf target -o ORGNAME -s SPACENAME
+cf target -o ORG_NAME -s SPACE_NAME
 ```
 
-where `ORGNAME` is the name of the org, and `SPACENAME` is the name of the space.
+where `ORG_NAME` is the name of the org, and `SPACE_NAME` is the name of the space.
 
 Once you set the target, the Cloud Foundry client remembers it until you change it.
 
 You can change space without changing org using:
 
 ```
-cf target -s SPACENAME
+cf target -s SPACE_NAME
 ```
 
 You should target the sandbox space while you are testing your app. You can do this by running:

--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -97,7 +97,7 @@ To set up a PostgreSQL service:
 
 You must bind your app to the PostgreSQL service to be able to access the database from the app.
 
-1. Use the [app's manifest](/deploying_apps.html#deployment-overview) to bind the app automatically to the service when you next deploy your app. For example:
+1. Use the [app's manifest](/deploying_apps.html#deployment-overview) to bind the app automatically to the service instance when you next deploy your app. An example manifest:
 
     ```
     --
@@ -107,7 +107,7 @@ You must bind your app to the PostgreSQL service to be able to access the databa
       - my-pg-service
     ```
 
-1. Deploy your app as normal.
+1. Deploy your app in line with your normal deployment process.
 
 This binds your app to a service instance called `my-pg-service`.
 
@@ -117,7 +117,7 @@ Refer to the Cloud Foundry documentation on [deploying with app manifests](https
 
 If you are not deploying your app with a `manifest.yml` file, you can manually bind your service instance to your app.
 
-1. Run the following code in the command line:
+1. Run the following:
 
     ```
     cf bind-service APP_NAME SERVICE_NAME
@@ -129,7 +129,7 @@ If you are not deploying your app with a `manifest.yml` file, you can manually b
     cf bind-service my-app my-pg-service
     ```
 
-1. Deploy your app as normal.
+1. Deploy your app in line with your normal deployment process.
 
 1. Run `cf env APP_NAME` to see the app's environment variables and confirm that the [VCAP_SERVICES environment variable](/deploying_apps.html#system-provided-environment-variables) contains the correct service connection details. It should be consistent with this example:
 

--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -131,45 +131,13 @@ If you are not deploying your app with a `manifest.yml` file, you can manually b
 
 1. Deploy your app in line with your normal deployment process.
 
-1. Run `cf env APP_NAME` to see the app's environment variables and confirm that the [VCAP_SERVICES environment variable](/deploying_apps.html#system-provided-environment-variables) contains the correct service connection details. It should be consistent with this example:
+### Connect to a PostgreSQL service from your app
 
-    ```
-    {
-     "VCAP_SERVICES": {
-      "postgres": [
-       {
-        "binding_name": null,
-        "credentials": {
-         "host": "rdsbroker-66ecd739-2e98-401a-9e45-17938165be06.c7uewwm9qebj.eu-west-1.rds.amazonaws.com",
-         "jdbcuri": "jdbc:postgresql://rdsbroker-66ecd739-2e98-401a-9e45-17938165be06.c7uewwm9qebj.eu-west-1.rds.amazonaws.com:5432/DATABASE_NAME?password=PASSWORD\u0026ssl=true\u0026user=USERNAME",
-         "name": "DATABASE_NAME",
-         "password": "PASSWORD",
-         "port": 5432,
-         "uri": "postgres://USERNAME:PASSWORD@rdsbroker-66ecd739-2e98-401a-9e45-17938165be06.c7uewwm9qebj.eu-west-1.rds.amazonaws.com:5432/DATABASE_NAME",
-         "username": "USERNAME"
-        },
-        "instance_name": "SERVICE_NAME",
-        "label": "postgres",
-        "name": "SERVICE_NAME",
-        "plan": "PLAN",
-        "provider": null,
-        "syslog_drain_url": null,
-        "tags": [
-         "postgres",
-         "relational"
-        ],
-        "volume_mounts": []
-       }
-      ]
-     }
-    }
-    ```
+Your app must make a [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) connection to the service. Some libraries use TLS by default, but others will need to be explicitly configured.
 
-    Your app must make a [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) connection to the service. Some libraries use TLS by default, but others will need to be explicitly configured.
+GOV.UK PaaS will automatically parse the ``VCAP_SERVICES`` [environment variable](/deploying_apps.html#system-provided-environment-variables) to get details of the service and then set the `DATABASE_URL` variable to the first database found.
 
-    GOV.UK PaaS will automatically parse the ``VCAP_SERVICES`` [environment variable](/deploying_apps.html#system-provided-environment-variables) to get details of the service and then set the `DATABASE_URL` variable to the first database found.
-
-    If your app writes database connection errors to `STDOUT` or `STDERR`, you can view recent errors with ``cf logs APP_NAME --recent``. See the section on [Logs](/monitoring_apps.html#logs) for details.
+If your app writes database connection errors to `STDOUT` or `STDERR`, you can view recent errors with `cf logs APP_NAME --recent`. See the section on [Logs](/monitoring_apps.html#logs) for details.
 
 ### Connect to a PostgreSQL service from your local machine
 

--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -595,7 +595,7 @@ You must bind your app to the MySQL service to be able to access the database fr
     Updated: 2016-08-23T15:42:02Z
     ```
 
-1. Run `cf env APPNAME` to see the app's environment variables and confirm that the [VCAP_SERVICES environment variable](/deploying_apps.html#system-provided-environment-variables) contains the correct service connection details. It should be consistent with this example:
+1. Run `cf env APP_NAME` to see the app's environment variables and confirm that the [VCAP_SERVICES environment variable](/deploying_apps.html#system-provided-environment-variables) contains the correct service connection details. It should be consistent with this example:
 
     ```
     {
@@ -633,7 +633,7 @@ You must bind your app to the MySQL service to be able to access the database fr
 
     GOV.UK PaaS will automatically parse the ``VCAP_SERVICES`` [environment variable](/deploying_apps.html#system-provided-environment-variables) to get details of the service and then set the `DATABASE_URL` variable to the first database found.
 
-    If your app writes database connection errors to `STDOUT` or `STDERR`, you can view recent errors with ``cf logs APPNAME --recent``. See the section on [Logs](/monitoring_apps.html#logs) for details.
+    If your app writes database connection errors to `STDOUT` or `STDERR`, you can view recent errors with ``cf logs APP_NAME --recent``. See the section on [Logs](/monitoring_apps.html#logs) for details.
 
 ### Connect to a MySQL service from your local machine
 
@@ -996,7 +996,7 @@ You must bind your app to the Redis service to be able to access the cache from 
     updated:   2018-02-21T10:52:31Z
     ```
 
-1. Run `cf env APPNAME` to see the app's environment variables and confirm that the [VCAP_SERVICES environment variable](/deploying_apps.html#system-provided-environment-variables) contains the correct service connection details. Example output:
+1. Run `cf env APP_NAME` to see the app's environment variables and confirm that the [VCAP_SERVICES environment variable](/deploying_apps.html#system-provided-environment-variables) contains the correct service connection details. Example output:
 
     ```
     {
@@ -1033,7 +1033,7 @@ You must bind your app to the Redis service to be able to access the cache from 
 
     Your app should parse the data in the `VCAP_SERVICES` environment variable in order to make a secure connection to Redis.
 
-    If your app writes service connection errors to `STDOUT` or `STDERR`, you can view recent errors with ``cf logs APPNAME --recent``. See the section on [Logs](/monitoring_apps.html#logs) for details.
+    If your app writes service connection errors to `STDOUT` or `STDERR`, you can view recent errors with ``cf logs APP_NAME --recent``. See the section on [Logs](/monitoring_apps.html#logs) for details.
 
 ### Connect to a Redis service instance from your local machine
 

--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -133,7 +133,7 @@ If you are not deploying your app with a `manifest.yml` file, you can manually b
 
 ### Connect to a PostgreSQL service from your app
 
-Your app must make a [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) connection to the service. Some libraries use TLS by default, but others will need to be explicitly configured.
+Your app must make a [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) connection to the service. Some libraries use TLS by default, but others will need to be manually configured.
 
 GOV.UK PaaS will automatically parse the ``VCAP_SERVICES`` [environment variable](/deploying_apps.html#system-provided-environment-variables) to get details of the service and then set the `DATABASE_URL` variable to the first database found.
 
@@ -167,7 +167,6 @@ You must:
 - [log into Cloud Foundry](/get_started.html#set-up-command-line)
 - [create the new PaaS-hosted PostgreSQL database](/deploying_services.html#set-up-a-postgresql-service)
 - [target the space](/deploying_apps.html#set-a-target) where your new database is located
-
 
 #### Non-PaaS to PaaS
 
@@ -216,7 +215,6 @@ To move data between two PaaS-hosted PostgreSQL databases:
     where `DESTINATION_SERVICE_NAME` is the name of the target database.
 
 Contact the PaaS team at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) if you have any questions.
-
 
 ### Upgrade PostgreSQL service plan
 
@@ -553,45 +551,15 @@ If you are not deploying your app with a `manifest.yml` file, you can manually b
 
 1. Deploy your app in line with your normal deployment process.
 
-1. Run `cf env APP_NAME` to see the app's environment variables and confirm that the [VCAP_SERVICES environment variable](/deploying_apps.html#system-provided-environment-variables) contains the correct service connection details. It should be consistent with this example:
+### Connect to a MySQL service from your app
 
-    ```
-    {
-     "VCAP_SERVICES": {
-      "mysql": [
-       {
-        "binding_name": null,
-        "credentials": {
-         "host": "rdsbroker-9bbd5eac-dcb1-4ddb-bfc6-addcfa085d6a.c7uewwm9qebj.eu-west-1.rds.amazonaws.com",
-         "jdbcuri": "jdbc:mysql://rdsbroker-9bbd5eac-dcb1-4ddb-bfc6-addcfa085d6a.c7uewwm9qebj.eu-west-1.rds.amazonaws.com:3306/DATABASE_NAME?user=USERNAME\u0026password=PASSWORD",
-         "name": "DATABASE_NAME",
-         "password": "PASSWORD",
-         "port": 3306,
-         "uri": "mysql://USERNAME:PASSWORD@rdsbroker-9bbd5eac-dcb1-4ddb-bfc6-addcfa085d6a.c7uewwm9qebj.eu-west-1.rds.amazonaws.com:3306/DATABASE_NAME?reconnect=true\u0026useSSL=true",
-         "username": "USERNAME"
-        },
-        "instance_name": "SERVICE_NAME",
-        "label": "mysql",
-        "name": "SERVICE_NAME",
-        "plan": "PLAN",
-        "provider": null,
-        "syslog_drain_url": null,
-        "tags": [
-         "mysql",
-         "relational"
-        ],
-        "volume_mounts": []
-       }
-      ]
-     }
-    }
-    ```
+Your app must make a [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) connection to the service. Some libraries use TLS by default, but others will need to be manually configured.
 
-    Your app must make a [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) connection to the service. Some libraries use TLS by default, but others will need to be explicitly configured. Refer to the Guidance section for information on how to securely connect either a [Drupal app](/guidance.html#connect-drupal-to-mysql) or a [Wordpress app](/guidance.html#connect-wordpress-to-mysql) to MySQL using SSL.
+GOV.UK PaaS will automatically parse the ``VCAP_SERVICES`` [environment variable](/deploying_apps.html#system-provided-environment-variables) to get details of the service and then set the `DATABASE_URL` variable to the first database found.
 
-    GOV.UK PaaS will automatically parse the ``VCAP_SERVICES`` [environment variable](/deploying_apps.html#system-provided-environment-variables) to get details of the service and then set the `DATABASE_URL` variable to the first database found.
+If your app writes database connection errors to `STDOUT` or `STDERR`, you can view recent errors with `cf logs APP_NAME --recent`. See the section on [Logs](/monitoring_apps.html#logs) for details.
 
-    If your app writes database connection errors to `STDOUT` or `STDERR`, you can view recent errors with ``cf logs APP_NAME --recent``. See the section on [Logs](/monitoring_apps.html#logs) for details.
+Refer to the Guidance section for information on how to securely connect either a [Drupal app](/guidance.html#connect-drupal-to-mysql) or a [Wordpress app](/guidance.html#connect-wordpress-to-mysql) to MySQL using SSL.
 
 ### Connect to a MySQL service from your local machine
 
@@ -937,44 +905,13 @@ If you are not deploying your app with a `manifest.yml` file, you can manually b
 
 1. Deploy your app in line with your normal deployment process.
 
-1. Run `cf env APP_NAME` to see the app's environment variables and confirm that the [VCAP_SERVICES environment variable](/deploying_apps.html#system-provided-environment-variables) contains the correct service connection details. Example output:
+### Connect to a PostgreSQL service from your app
 
-    ```
-    {
-     "VCAP_SERVICES": {
-      "redis": [
-       {
-        "binding_name": null,
-        "credentials": {
-         "host": "clustercfg.cf-u7zpvbwzxmrvu.p9lva7.euw1.cache.amazonaws.com",
-         "name": "cf-u7zpvbwzxmrvu",
-         "password": "PASSWORD",
-         "port": 6379,
-         "tls_enabled": true,
-         "uri": "rediss://x:PASSWORD@clustercfg.cf-u7zpvbwzxmrvu.p9lva7.euw1.cache.amazonaws.com:6379"
-        },
-        "instance_name": "my-redis-service",
-        "label": "redis",
-        "name": "my-redis-service",
-        "plan": "tiny-clustered-3.2",
-        "provider": null,
-        "syslog_drain_url": null,
-        "tags": [
-         "elasticache",
-         "redis"
-        ],
-        "volume_mounts": []
-       }
-      ]
-     }
-    }
-    ```
+Your app must make a [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) connection to the service. Some libraries use TLS by default, but others will need to be manually configured.
 
-    Your app must make a [TLS connection](https://en.wikipedia.org/wiki/Transport_Layer_Security) to the service. Some libraries use TLS by default, but others will need to be explicitly configured.
+Your app should parse the ``VCAP_SERVICES`` [environment variable](/deploying_apps.html#system-provided-environment-variables) to make a secure connection to Redis.
 
-    Your app should parse the data in the `VCAP_SERVICES` environment variable in order to make a secure connection to Redis.
-
-    If your app writes service connection errors to `STDOUT` or `STDERR`, you can view recent errors with ``cf logs APP_NAME --recent``. See the section on [Logs](/monitoring_apps.html#logs) for details.
+If your app writes database connection errors to `STDOUT` or `STDERR`, you can view recent errors with `cf logs APP_NAME --recent`. See the section on [Logs](/monitoring_apps.html#logs) for details.
 
 ### Connect to a Redis service instance from your local machine
 

--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -905,7 +905,7 @@ If you are not deploying your app with a `manifest.yml` file, you can manually b
 
 1. Deploy your app in line with your normal deployment process.
 
-### Connect to a PostgreSQL service from your app
+### Connect to a Redis service from your app
 
 Your app must make a [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) connection to the service. Some libraries use TLS by default, but others will need to be manually configured.
 

--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -552,48 +552,38 @@ To set up a MySQL service:
 
 You must bind your app to the MySQL service to be able to access the database from the app.
 
-1. Run the following code in the command line:
+1. Use the [app's manifest](/deploying_apps.html#deployment-overview) to bind the app automatically to the service instance when you next deploy your app. An example manifest:
 
     ```
-    cf bind-service APPLICATION SERVICE_NAME
+    --
+    applications:
+      - name: my-app
+        services:
+        - my-ms-service
+    ```
+1. Deploy your app in line with your normal deployment process.
+
+This binds your app to a service instance called `my-ms-service`.
+
+Refer to the Cloud Foundry documentation on [deploying with app manifests](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#services-block) [external link] for more information.
+
+#### Use the cf bind-service command
+
+If you are not deploying your app with a `manifest.yml` file, you can manually bind your service instance to your app.
+
+1. Run the following:
+
+    ```
+    cf bind-service APP_NAME SERVICE_NAME
     ```
 
-    where `APPLICATION` is the name of a deployed instance of your application (exactly as specified in your app's `manifest.yml` file or push command) and `SERVICE_NAME` is a unique descriptive name for this service instance. For example:
+    where `APP_NAME` is the exact name of a deployed instance of your application and `SERVICE_NAME` is the name of the service instance you created. For example:
 
     ```
     cf bind-service my-app my-ms-service
     ```
 
-1. If the app is already running, you should restage the app to make sure it connects:
-
-    ```
-    cf restage APPLICATION
-    ```
-
-1. To confirm that the service is bound to the app, run:
-
-    ```
-    cf service SERVICE_NAME
-    ```
-
-    and check the `Bound apps:` line of the output.
-
-    ```
-    Service instance: my-ms-service
-    Service: mysql
-    Bound apps: my-app
-    Tags:
-    Plan: medium-5.7
-    Description: AWS RDS MySQL service
-    Documentation url: https://aws.amazon.com/documentation/rds/
-    Dashboard:
-
-    Last Operation
-    Status: create succeeded
-    Message: DB Instance 'rdsbroker-9f053413-97a5-461f-aa41-fe6e29db323e' status is 'available'
-    Started: 2016-08-23T15:34:41Z
-    Updated: 2016-08-23T15:42:02Z
-    ```
+1. Deploy your app in line with your normal deployment process.
 
 1. Run `cf env APP_NAME` to see the app's environment variables and confirm that the [VCAP_SERVICES environment variable](/deploying_apps.html#system-provided-environment-variables) contains the correct service connection details. It should be consistent with this example:
 
@@ -946,55 +936,38 @@ To set up a Redis service:
 
 You must bind your app to the Redis service to be able to access the cache from the app.
 
-1. Run the following in the command line:
+1. Use the [app's manifest](/deploying_apps.html#deployment-overview) to bind the app automatically to the service instance when you next deploy your app. An example manifest:
 
     ```
-    cf bind-service APPLICATION SERVICE_NAME
+    --
+    applications:
+      - name: my-app
+        services:
+        - my-redis-service
+    ```
+1. Deploy your app in line with your normal deployment process.
+
+This binds your app to a service instance called `my-redis-service`.
+
+Refer to the Cloud Foundry documentation on [deploying with app manifests](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#services-block) [external link] for more information.
+
+#### Use the cf bind-service command
+
+If you are not deploying your app with a `manifest.yml` file, you can manually bind your service instance to your app.
+
+1. Run the following:
+
+    ```
+    cf bind-service APP_NAME SERVICE_NAME
     ```
 
-    where `APPLICATION` is the name of a deployed instance of your application (exactly as specified in your app's `manifest.yml` file or push command) and `SERVICE_NAME` is a unique descriptive name for this service instance. For example:
+    where `APP_NAME` is the exact name of a deployed instance of your application and `SERVICE_NAME` is the name of the service instance you created. For example:
 
     ```
     cf bind-service my-app my-redis-service
     ```
 
-1. If the app is already running, you should restage the app to make sure it connects:
-
-    ```
-    cf restage APPLICATION
-    ```
-
-1. To confirm that the service is bound to the app, run:
-
-    ```
-    cf service SERVICE_NAME
-    ```
-
-    and check the `bound apps:` line of the output.
-
-    ```
-    name:            my-redis-service
-    service:         redis
-    bound apps:      my-app
-    tags:
-    plan:            tiny-clustered-3.2
-    description:     AWS ElastiCache Redis service
-    documentation:
-    dashboard:
-
-    Showing status of last operation from service testing-time...
-
-    status:    create succeeded
-    message:   ---
-               status               : available
-               cluster id           : cf-u7zpvbwzxmrvu
-               engine version       : 3.2.6
-               maxmemory policy     : volatile-lru
-               maintenance window   : sun:23:00-mon:01:30
-               daily backup window  : 02:00-05:00
-    started:   2018-02-21T10:44:16Z
-    updated:   2018-02-21T10:52:31Z
-    ```
+1. Deploy your app in line with your normal deployment process.
 
 1. Run `cf env APP_NAME` to see the app's environment variables and confirm that the [VCAP_SERVICES environment variable](/deploying_apps.html#system-provided-environment-variables) contains the correct service connection details. Example output:
 
@@ -1277,53 +1250,41 @@ Before using Elasticsearch as your primary data store, you should assess if an [
 
 ### Bind an Elasticsearch service to your apps
 
-To access the cache from the app, you must bind your app to the Elasticsearch service:
+To access the cache from the app, you must bind your app to the Elasticsearch service.
 
-1. Run the following in the command line:
+1. Use the [app's manifest](/deploying_apps.html#deployment-overview) to bind the app automatically to the service instance when you next deploy your app. An example manifest:
+
+    ```
+    --
+    applications:
+      - name: my-app
+        services:
+        - my-es-service
+    ```
+
+1. Deploy your app in line with your normal deployment process.
+
+This binds your app to a service instance called `my-es-service`.
+
+Refer to the Cloud Foundry documentation on [deploying with app manifests](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#services-block) [external link] for more information.
+
+#### Use the cf bind-service command
+
+If you are not deploying your app with a `manifest.yml` file, you can manually bind your service instance to your app.
+
+1. Run the following:
 
     ```
     cf bind-service APP_NAME SERVICE_NAME
     ```
 
-    where `APP_NAME` is the name of a deployed instance of your app (exactly as specified in your app's `manifest.yml` or push command) and `SERVICE_NAME` is a unique descriptive name for this service instance. For example:
+    where `APP_NAME` is the exact name of a deployed instance of your application and `SERVICE_NAME` is the name of the service instance you created. For example:
 
     ```
     cf bind-service my-app my-es-service
     ```
 
-2. If the app is already running, you should restage it to make sure it connects to Elasticsearch:
-
-    ```
-    cf restage APP_NAME
-    ```
-
-3. To confirm the service is bound to the app, run:
-
-    ```
-    cf service SERVICE_NAME
-    ```
-
-    and check the `bound apps:` line of the output.
-
-    ```
-    name:            my-es-service
-    service:         elasticsearch
-    bound apps:      my-app
-    tags:
-    plan:            small-ha-6.x
-    description:     Elasticsearch instances provisioned via Aiven
-    documentation:
-    dashboard:
-
-    Showing status of last operation from service my-es-service...
-
-    status:    create succeeded
-    message:   Last operation succeeded
-    started:   2018-08-02T10:17:30Z
-    updated:   2018-08-02T10:21:35Z
-    ```
-
-You can also use the app's `manifest.yml` to bind apps to service instances during app deployment. You can use the same `manifest.yml` to deploy your app to different environments.
+1. Deploy your app in line with your normal deployment process.
 
 Refer to the Cloud Foundry documentation on [deploying with app manifests](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#services-block) [external link] for more information.
 

--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -95,9 +95,9 @@ To set up a PostgreSQL service:
 
 ### Bind a PostgreSQL service to your app
 
-You must bind your app to the PostgreSQL service to be able to access the database from the app.
+You must bind your app to the PostgreSQL service so you can access the database from the app.
 
-1. Use the [app's manifest](/deploying_apps.html#deployment-overview) to bind the app automatically to the service instance when you next deploy your app. An example manifest:
+1. Use the [app's manifest](/deploying_apps.html#deployment-overview) to bind the app to the service instance. It will bind automatically when you next deploy your app. An example manifest:
 
     ```
     --
@@ -115,7 +115,7 @@ Refer to the Cloud Foundry documentation on [deploying with app manifests](https
 
 #### Use the cf bind-service command
 
-If you are not deploying your app with a `manifest.yml` file, you can manually bind your service instance to your app.
+Alternatively, you can manually bind your service instance to your app.
 
 1. Run the following:
 
@@ -516,9 +516,9 @@ To set up a MySQL service:
 
 ### Bind a MySQL service to your app
 
-You must bind your app to the MySQL service to be able to access the database from the app.
+You must bind your app to the MySQL service so you can access the database from the app.
 
-1. Use the [app's manifest](/deploying_apps.html#deployment-overview) to bind the app automatically to the service instance when you next deploy your app. An example manifest:
+1. Use the [app's manifest](/deploying_apps.html#deployment-overview) to bind the app to the service instance. It will bind automatically when you next deploy your app. An example manifest:
 
     ```
     --
@@ -535,7 +535,7 @@ Refer to the Cloud Foundry documentation on [deploying with app manifests](https
 
 #### Use the cf bind-service command
 
-If you are not deploying your app with a `manifest.yml` file, you can manually bind your service instance to your app.
+Alternatively, you can manually bind your service instance to your app.
 
 1. Run the following:
 
@@ -870,9 +870,9 @@ To set up a Redis service:
 
 ### Bind a Redis service to your app
 
-You must bind your app to the Redis service to be able to access the cache from the app.
+You must bind your app to the Redis service so you can access the cache from the app.
 
-1. Use the [app's manifest](/deploying_apps.html#deployment-overview) to bind the app automatically to the service instance when you next deploy your app. An example manifest:
+1. Use the [app's manifest](/deploying_apps.html#deployment-overview) to bind the app to the service instance. It will bind automatically when you next deploy your app. An example manifest:
 
     ```
     --
@@ -889,7 +889,7 @@ Refer to the Cloud Foundry documentation on [deploying with app manifests](https
 
 #### Use the cf bind-service command
 
-If you are not deploying your app with a `manifest.yml` file, you can manually bind your service instance to your app.
+Alternatively, you can manually bind your service instance to your app.
 
 1. Run the following:
 
@@ -1157,7 +1157,7 @@ Before using Elasticsearch as your primary data store, you should assess if an [
 
 To access the cache from the app, you must bind your app to the Elasticsearch service.
 
-1. Use the [app's manifest](/deploying_apps.html#deployment-overview) to bind the app automatically to the service instance when you next deploy your app. An example manifest:
+1. Use the [app's manifest](/deploying_apps.html#deployment-overview) to bind the app to the service instance. It will bind automatically when you next deploy your app. An example manifest:
 
     ```
     --
@@ -1175,7 +1175,7 @@ Refer to the Cloud Foundry documentation on [deploying with app manifests](https
 
 #### Use the cf bind-service command
 
-If you are not deploying your app with a `manifest.yml` file, you can manually bind your service instance to your app.
+Alternatively, you can manually bind your service instance to your app.
 
 1. Run the following:
 

--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -97,50 +97,41 @@ To set up a PostgreSQL service:
 
 You must bind your app to the PostgreSQL service to be able to access the database from the app.
 
+1. Use the [app's manifest](/deploying_apps.html#deployment-overview) to bind the app automatically to the service when you next deploy your app. For example:
+
+    ```
+    --
+    applications:
+    - name: my-app
+      services:
+      - my-pg-service
+    ```
+
+1. Deploy your app as normal.
+
+This binds your app to a service instance called `my-pg-service`.
+
+Refer to the Cloud Foundry documentation on [deploying with app manifests](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#services-block) [external link] for more information.
+
+#### Use the cf bind-service command
+
+If you are not deploying your app with a `manifest.yml` file, you can manually bind your service instance to your app.
+
 1. Run the following code in the command line:
 
     ```
-    cf bind-service APPLICATION SERVICE_NAME
+    cf bind-service APP_NAME SERVICE_NAME
     ```
 
-    where `APPLICATION` is the name of a deployed instance of your application (exactly as specified in your manifest or push command) and `SERVICE_NAME` is a unique descriptive name for this service instance. For example:
+    where `APP_NAME` is the exact name of a deployed instance of your application and `SERVICE_NAME` is the name of the service instance you created. For example:
 
     ```
     cf bind-service my-app my-pg-service
     ```
 
-1. If the app is already running, you should restage the app to make sure it connects:
+1. Deploy your app as normal.
 
-    ```
-    cf restage APPLICATION
-    ```
-
-1. To confirm that the service is bound to the app, run:
-
-    ```
-    cf service SERVICE_NAME
-    ```
-
-    and check the `Bound apps:` line of the output.
-
-    ```
-    Service instance: my-pg-service
-    Service: postgres
-    Bound apps: my-app
-    Tags:
-    Plan: small-9.5
-    Description: AWS RDS PostgreSQL service
-    Documentation url: https://aws.amazon.com/documentation/rds/
-    Dashboard:
-
-    Last Operation
-    Status: create succeeded
-    Message: DB Instance 'rdsbroker-9f053413-97a5-461f-aa41-fe6e29db323e' status is 'available'
-    Started: 2016-08-23T15:34:41Z
-    Updated: 2016-08-23T15:42:02Z
-    ```
-
-1. Run `cf env APPNAME` to see the app's environment variables and confirm that the [VCAP_SERVICES environment variable](/deploying_apps.html#system-provided-environment-variables) contains the correct service connection details. It should be consistent with this example:
+1. Run `cf env APP_NAME` to see the app's environment variables and confirm that the [VCAP_SERVICES environment variable](/deploying_apps.html#system-provided-environment-variables) contains the correct service connection details. It should be consistent with this example:
 
     ```
     {
@@ -178,7 +169,7 @@ You must bind your app to the PostgreSQL service to be able to access the databa
 
     GOV.UK PaaS will automatically parse the ``VCAP_SERVICES`` [environment variable](/deploying_apps.html#system-provided-environment-variables) to get details of the service and then set the `DATABASE_URL` variable to the first database found.
 
-    If your app writes database connection errors to `STDOUT` or `STDERR`, you can view recent errors with ``cf logs APPNAME --recent``. See the section on [Logs](/monitoring_apps.html#logs) for details.
+    If your app writes database connection errors to `STDOUT` or `STDERR`, you can view recent errors with ``cf logs APP_NAME --recent``. See the section on [Logs](/monitoring_apps.html#logs) for details.
 
 ### Connect to a PostgreSQL service from your local machine
 
@@ -300,7 +291,7 @@ You must unbind the PostgreSQL service before you can delete it. To unbind the P
 cf unbind-service APPLICATION SERVICE_NAME
 ```
 
-where `APPLICATION` is the name of a deployed instance of your application (exactly as specified in your manifest or push command) and `SERVICE_NAME` is a unique descriptive name for this service instance, for example:
+where `APPLICATION` is the name of a deployed instance of your application (exactly as specified in your app's `manifest.yml` file or push command) and `SERVICE_NAME` is a unique descriptive name for this service instance, for example:
 
 ```
 cf unbind-service my-app my-pg-service
@@ -567,7 +558,7 @@ You must bind your app to the MySQL service to be able to access the database fr
     cf bind-service APPLICATION SERVICE_NAME
     ```
 
-    where `APPLICATION` is the name of a deployed instance of your application (exactly as specified in your manifest or push command) and `SERVICE_NAME` is a unique descriptive name for this service instance. For example:
+    where `APPLICATION` is the name of a deployed instance of your application (exactly as specified in your app's `manifest.yml` file or push command) and `SERVICE_NAME` is a unique descriptive name for this service instance. For example:
 
     ```
     cf bind-service my-app my-ms-service
@@ -762,7 +753,7 @@ You must unbind the MySQL service before you can delete it. To unbind the MySQL 
 cf unbind-service APPLICATION SERVICE_NAME
 ```
 
-where `APPLICATION` is the name of a deployed instance of your application (exactly as specified in your manifest or push command) and `SERVICE_NAME` is a unique descriptive name for this service instance, for example:
+where `APPLICATION` is the name of a deployed instance of your application (exactly as specified in your app's `manifest.yml` file or push command) and `SERVICE_NAME` is a unique descriptive name for this service instance, for example:
 
 ```
 cf unbind-service my-app my-ms-service
@@ -961,7 +952,7 @@ You must bind your app to the Redis service to be able to access the cache from 
     cf bind-service APPLICATION SERVICE_NAME
     ```
 
-    where `APPLICATION` is the name of a deployed instance of your application (exactly as specified in your manifest or push command) and `SERVICE_NAME` is a unique descriptive name for this service instance. For example:
+    where `APPLICATION` is the name of a deployed instance of your application (exactly as specified in your app's `manifest.yml` file or push command) and `SERVICE_NAME` is a unique descriptive name for this service instance. For example:
 
     ```
     cf bind-service my-app my-redis-service
@@ -1089,7 +1080,7 @@ You must unbind the Redis service before you can delete your service instance. T
 cf unbind-service APPLICATION SERVICE_NAME
 ```
 
-where `APPLICATION` is the name of a deployed instance of your application (exactly as specified in your manifest or push command) and `SERVICE_NAME` is a unique descriptive name for this service instance, for example:
+where `APPLICATION` is the name of a deployed instance of your application (exactly as specified in your app's `manifest.yml` file or push command) and `SERVICE_NAME` is a unique descriptive name for this service instance, for example:
 
 ```
 cf unbind-service my-app my-redis-service
@@ -1294,7 +1285,7 @@ To access the cache from the app, you must bind your app to the Elasticsearch se
     cf bind-service APP_NAME SERVICE_NAME
     ```
 
-    where `APP_NAME` is the name of a deployed instance of your app (exactly as specified in your manifest or push command) and `SERVICE_NAME` is a unique descriptive name for this service instance. For example:
+    where `APP_NAME` is the name of a deployed instance of your app (exactly as specified in your app's `manifest.yml` or push command) and `SERVICE_NAME` is a unique descriptive name for this service instance. For example:
 
     ```
     cf bind-service my-app my-es-service
@@ -1352,7 +1343,7 @@ You must unbind the Elasticsearch service before you can delete it. Run the foll
 cf unbind-service APP_NAME SERVICE_NAME
 ```
 
-where `APP_NAME` is your app's deployed instance name as specified in your manifest or push command, and `SERVICE_NAME` is a unique descriptive name for this service instance, for example:
+where `APP_NAME` is your app's deployed instance name as specified in your app's `manifest.yml` or push command, and `SERVICE_NAME` is a unique descriptive name for this service instance, for example:
 
 ```
 cf unbind-service my-app my-es-service


### PR DESCRIPTION
What
----

- Added manifest method of binding an app to a backing service.
- Made text more active and in line with style.
- Added new "Connect to a [NAME] service from your app" section. This contains the existing content on TLS connections and environment variables. It links to the environment variables section in deploying apps, which now has the VCAP_SERVICES example text.

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Check it fulfils story: https://www.pivotaltracker.com/story/show/159520712

Who can review
--------------

Anyone excluding Jon Glassman or Jonathan Matthews
