### PR TITLE
Use https:// instead of git:// for middleman-search gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,4 @@ gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
 gem 'govuk_tech_docs'
-gem 'middleman-search', :git => 'git://github.com/alphagov/middleman-search.git'
+gem 'middleman-search', :git => 'https://github.com/alphagov/middleman-search.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/alphagov/middleman-search.git
+  remote: https://github.com/alphagov/middleman-search.git
   revision: 19df7578dc20621b60dfbc5e4dc986ac4f064c6b
   specs:
     middleman-search (0.10.0)


### PR DESCRIPTION
## What

This avoids the following warning when bundling:

>  The git source `git://github.com/alphagov/middleman-search.git` uses
>  the `git` protocol, which transmits data without encryption. Disable
>  this warning with `bundle config git.allow_insecure true`, or switch
>  to the `https` protocol to keep your data secure.

This also allows bundling to work when operating behing a broken ISP
filtering proxy server that blocks non-http access (eg VirginMedia)

How to review
-------------

* Verify `bundle install` still works.
* Verify that this doesn't actually change any versions.

Who can review
--------------

Not me.