### PR TITLE
Fix broken links

### DIFF
--- a/source/documentation/deploying_services/configure_cdn.md
+++ b/source/documentation/deploying_services/configure_cdn.md
@@ -5,7 +5,7 @@ There are two ways to configure your own CDN:
  - use Cloud Foundry commands
  - amend HTTP request headers
 
-You should use these methods if you need access to features that are not provided by the `cdn-route` service. The [`cdn-route`](/deploying_services.html#configuring-your-custom-domain) section has information on the features provided by the service.
+You should use these methods if you need access to features that are not provided by the `cdn-route` service. The [`cdn-route`](/deploying_services/use_a_custom_domain/#set-up-a-custom-domain-using-the-cdn-route-service) section has information on the features provided by the service.
 
 There are many different CDNs available. Contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) to discuss best practice for configuring your CDN to work with the PaaS.
 

--- a/source/documentation/deploying_services/route_services.md
+++ b/source/documentation/deploying_services/route_services.md
@@ -12,7 +12,7 @@ Using route services has some consequences to be aware of:
 
 ### User-provided Route Services
 
-Tenants can define their own route service instance by using a [user-provided service instance](/https://docs.cloudfoundry.org/devguide/services/user-provided.html) [external link] that points to any HTTPS service. This endpoint must fulfill the following requirements:
+Tenants can define their own route service instance by using a [user-provided service instance](https://docs.cloudfoundry.org/devguide/services/user-provided.html) [external link] that points to any HTTPS service. This endpoint must fulfill the following requirements:
 
 - It must be a HTTPS endpoint with a valid certificate.
 - It can be a application running in the platform itself or an external service on the Internet.


### PR DESCRIPTION
What
----
Fixed broken links:

1. Change link on user-provided service instance from `https://docs.cloud.service.gov.uk/https://docs.cloudfoundry.org/devguide/services/user-provided.html` to	`https://docs.cloudfoundry.org/devguide/services/user-provided.html` by removing superfluous "\"

2. Changed cdn-route link to `deploying_services/use_a_custom_domain/#set-up-a-custom-domain-using-the-cdn-route-service`


How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Check that links now work

Who can review
--------------

Anyone except Jon Glassman
