### PR TITLE
Expand linkchecker testing to catch more 404s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .DEFAULT_GOAL := help
 
+LINKCHECKER := linkchecker --ignore-url=^mailto:
+SERVER_PORT?=4567
+
 .PHONY: help
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -12,11 +15,26 @@ dependencies: ## Install dependencies
 .PHONY: build
 build: ## Builds the project
 	@echo "Run middleman..."
-	bundle exec middleman build
+	bundle exec middleman build --verbose
 	@echo "Copy additional files..."
 	cp googlec7239f490e1990a5.html build
 
 .PHONY: test
-test: ## Runs the tests
-	bundle exec middleman build --verbose
-	linkchecker ./build/
+test: test-filesystem test-local-http ## Runs the tests
+
+.PHONY: test-filesystem
+test-filesystem: build ## checks links against the build dir directly
+	$(LINKCHECKER) ./build/
+
+.PHONY: test-local-http
+test-local-http: build ## checks links against the build dir over HTTP
+	ruby \
+	  -run \
+	  -ehttpd \
+	  ./build/ \
+	  -p$(SERVER_PORT) \
+	>/dev/null 2>&1 & SERVER_PID=$$! ; \
+	$(LINKCHECKER) http://localhost:$(SERVER_PORT) ; \
+	LINKCHECKER_STATUS=$$? ; \
+	kill $${SERVER_PID} ; \
+	exit $${LINKCHECKER_STATUS}

--- a/source/documentation/deploying_services/postgresql.md
+++ b/source/documentation/deploying_services/postgresql.md
@@ -181,7 +181,7 @@ To move data from a non-PaaS PostgreSQL database to a PaaS PostgreSQL database:
 
 To move data between two PaaS-hosted PostgreSQL databases:
 
-1. Use the [Conduit plugin](/deploying_services.html#connect-to-a-postgresql-service-from-your-local-machine) to connect to the source database and export the data into an SQL file by running:
+1. Use the [Conduit plugin](/deploying_services/postgresql/#connect-to-a-postgresql-service-from-your-local-machine) to connect to the source database and export the data into an SQL file by running:
 
     ```
     cf conduit SERVICE_NAME -- pg_dump --file DATA_FILE_NAME


### PR DESCRIPTION
What
-----

When running linkchecker directly against the build directory, it checks
links that move up/across the directory hierarchy only for link correctness, not
target existence. This means that, before this commit, our standard "make test"
pre-merge only checked that internal links reached pages which exist in
around 40% of cases. Using `--check-extern` isn't an option, as this not
only makes linkchecker check off-site hosts, but will also fail with
`/`-prefixed, relative (internal) links when it discovers that, on the
filesystem, `/stylesheets/foo.css` doesn't exist. There doesn't appear
to be a way to tell linkchecker to assume a `file://path/to/build/dir`
base URL.

To get round this, we use the fact that linkchecker *will* check the
internal consistency of links when given an `http://` URL to check. This
is used in a new Make target: `test-local-http`.

To serve the build dir over HTTP, a simple ruby one-liner was
arbitrarily chosen as "probably having its dependencies present in all
environments which will run this". This might need revisiting if this
assumption turns out to be incorrect. A bit of shell hackery is
needed to clean up the http server and still exit the target with the
linkchecker's exit code.

The existing `test` Make target is redefined to run the fast test target
and then the longer one, allowing devs to have fail-fast behaviour
whilst requiring no changes in CI to pick up the wider set of 404
assertions.

How to review
-------------

- Observe that `92a2a48` fails in Travis, as it introduces these additional tests and catches an additional 404
- Observe that a subsequent commit from @jonathanglassman fixes this 404, and turns the tests green


Who can review
--------------

Anyone but me.