### PR TITLE
[#159073525] UK based PaaS

### DIFF
--- a/source/documentation/getting_started/get_started.md
+++ b/source/documentation/getting_started/get_started.md
@@ -6,15 +6,17 @@ Your department, agency or team must have a GOV.UK PaaS account. This account is
 
 Once your department, agency or team has an org account, you will need a personal account. Ask your [org manager](orgs_spaces_users.html#org-manager) to authorise the creation of your personal account.
 
-The GOV.UK PaaS is hosted in two independent regions, London and Ireland. The GOV.UK PaaS team creates new accounts in the London region unless you request otherwise. 
+The GOV.UK PaaS is hosted in 2 independent regions, London and Ireland. 
+
+By default, the GOV.UK PaaS team creates new accounts in the London region unless you request otherwise during sign up. 
 
 To provide you with an account, we need to store some personal data about you. Please see our [privacy notice](https://www.cloud.service.gov.uk/privacy-notice) for details.
 
-Once you have a personal account, you can access either the [London](https://admin.london.cloud.service.gov.uk/) or the [Ireland](https://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool (requires sign in), depending on which region your org is hosted in. This tool allows you to, depending on your user role permissions, view and manage your [orgs](orgs_spaces_users.html#organisations), [spaces](orgs_spaces_users.html#spaces) and [users](orgs_spaces_users.html#users-and-user-roles) without using the command line.
+Once you have a personal account, you can access the GOV.UK PaaS admin tool for either the [London](https://admin.london.cloud.service.gov.uk/) or the [Ireland](https://admin.cloud.service.gov.uk/) region (requires sign in). This tool allows you to view and manage your [orgs](orgs_spaces_users.html#organisations), [spaces](orgs_spaces_users.html#spaces) and [users](orgs_spaces_users.html#users-and-user-roles) without using the command line. Your level of access depends on your user role permissions.
 
 Contact us by emailing [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) if you have any questions.
 
-## Set up command line
+## Set up the Cloud Foundry command line
 
 GOV.UK PaaS is hosted on [Cloud Foundry](https://www.cloudfoundry.org/) [external link]. You must use the Cloud Foundry command line interface (CLI) to manage your apps hosted on the GOV.UK PaaS. To set it up:
 
@@ -40,9 +42,9 @@ GOV.UK PaaS is hosted on [Cloud Foundry](https://www.cloudfoundry.org/) [externa
 
     `USERNAME` is your personal account email address.
 
-4. Enter your password (you set this password when you clicked on the invite link in your welcome email).
+4. Enter the password you set during the sign up process.
 
-Once you are logged in, run `cf` in the command line to see all available commands.
+When you are signed in, run `cf` in the command line to see all available commands.
 
 ## Deploy a test static HTML page
 

--- a/source/documentation/getting_started/get_started.md
+++ b/source/documentation/getting_started/get_started.md
@@ -8,7 +8,7 @@ Once your department, agency or team has an org account, you will need an indivi
 
 To provide you with an account, we need to store some personal data about you. Please see our [privacy notice](https://www.cloud.service.gov.uk/privacy-notice) for details.
 
-Once you have an individual account, you can access the [GOV.UK PaaS admin tool](https://admin.cloud.service.gov.uk/) (requires sign in). This tool allows you to, depending on your user role permissions, view and manage your [orgs](orgs_spaces_users.html#organisations), [spaces](orgs_spaces_users.html#spaces) and [users](orgs_spaces_users.html#users-and-user-roles) without using the command line.
+Once you have an individual account, you can access the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool (requires sign in). This tool allows you to, depending on your user role permissions, view and manage your [orgs](orgs_spaces_users.html#organisations), [spaces](orgs_spaces_users.html#spaces) and [users](orgs_spaces_users.html#users-and-user-roles) without using the command line.
 
 Contact us by emailing [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) if you have any questions.
 

--- a/source/documentation/getting_started/get_started.md
+++ b/source/documentation/getting_started/get_started.md
@@ -4,13 +4,13 @@
 
 Your department, agency or team must have a GOV.UK PaaS account. This account is called an organisation, or [org](orgs_spaces_users.html#organisations). Sign up for an org account at [https://www.cloud.service.gov.uk/signup](https://www.cloud.service.gov.uk/signup).
 
-Once your department, agency or team has an org account, you will need an individual account. Ask your [org manager](orgs_spaces_users.html#org-manager) to authorise the creation of your individual account.
+Once your department, agency or team has an org account, you will need a personal account. Ask your [org manager](orgs_spaces_users.html#org-manager) to authorise the creation of your personal account.
 
-The GOV.UK PaaS is hosted in two locations, London and Ireland. The GOV.UK PaaS team creates all new orgs on the London-based GOV.UK PaaS by default. If you already have an account on the Ireland-based GOV.UK PaaS and request a new org, we will create this new org and account on the London-based GOV.UK PaaS, and you will have two separate accounts.
+The GOV.UK PaaS is hosted in two regions, London and Ireland. The GOV.UK PaaS team creates all new orgs on the London-based GOV.UK PaaS by default. If you already have an account on the Ireland-based GOV.UK PaaS and request a new org, we will create this new org and account on the London-based GOV.UK PaaS, and you will have two separate accounts.
 
 To provide you with an account, we need to store some personal data about you. Please see our [privacy notice](https://www.cloud.service.gov.uk/privacy-notice) for details.
 
-Once you have an individual account, you can access either the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool (requires sign in), depending on where your org is hosted. This tool allows you to, depending on your user role permissions, view and manage your [orgs](orgs_spaces_users.html#organisations), [spaces](orgs_spaces_users.html#spaces) and [users](orgs_spaces_users.html#users-and-user-roles) without using the command line.
+Once you have a personal account, you can access either the [London](https://admin.london.cloud.service.gov.uk/) or the [Ireland](https://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool (requires sign in), depending on which region your org is hosted in. This tool allows you to, depending on your user role permissions, view and manage your [orgs](orgs_spaces_users.html#organisations), [spaces](orgs_spaces_users.html#spaces) and [users](orgs_spaces_users.html#users-and-user-roles) without using the command line.
 
 Contact us by emailing [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) if you have any questions.
 
@@ -26,19 +26,19 @@ GOV.UK PaaS is hosted on [Cloud Foundry](https://www.cloudfoundry.org/) [externa
 
     Depending on your network configuration, you might need to set an [`HTTP_PROXY` environment variable](https://docs.cloudfoundry.org/cf-cli/http-proxy.html) [external link] for the CLI to connect. Contact your network administrator for your configuration settings.
 
-3. Sign in to Cloud Foundry. If your org is hosted on the London-based GOV.UK PaaS, run:
+3. Sign in to Cloud Foundry. If your org is hosted on the London region, run:
 
     ```
     cf login -a api.london.cloud.service.gov.uk -u USERNAME
     ```
 
-    If your org is hosted on the Ireland-based GOV.UK PaaS, run:
+    If your org is hosted on the Ireland region, run:
 
     ```
     cf login -a api.cloud.service.gov.uk -u USERNAME
     ```
 
-    `USERNAME` is your individual account email address.
+    `USERNAME` is your personal account email address.
 
 4. Enter your password (you set this password when you clicked on the invite link in your welcome email).
 

--- a/source/documentation/getting_started/get_started.md
+++ b/source/documentation/getting_started/get_started.md
@@ -6,9 +6,11 @@ Your department, agency or team must have a GOV.UK PaaS account. This account is
 
 Once your department, agency or team has an org account, you will need an individual account. Ask your [org manager](orgs_spaces_users.html#org-manager) to authorise the creation of your individual account.
 
+The GOV.UK PaaS is hosted in two locations, London and Ireland. The GOV.UK PaaS team creates all new orgs on the London-based GOV.UK PaaS by default. If you already have an account on the Ireland-based GOV.UK PaaS and request a new org, we will create this new org and account on the London-based GOV.UK PaaS, and you will have two separate accounts.
+
 To provide you with an account, we need to store some personal data about you. Please see our [privacy notice](https://www.cloud.service.gov.uk/privacy-notice) for details.
 
-Once you have an individual account, you can access the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool (requires sign in). This tool allows you to, depending on your user role permissions, view and manage your [orgs](orgs_spaces_users.html#organisations), [spaces](orgs_spaces_users.html#spaces) and [users](orgs_spaces_users.html#users-and-user-roles) without using the command line.
+Once you have an individual account, you can access either the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool (requires sign in), depending on where your org is hosted. This tool allows you to, depending on your user role permissions, view and manage your [orgs](orgs_spaces_users.html#organisations), [spaces](orgs_spaces_users.html#spaces) and [users](orgs_spaces_users.html#users-and-user-roles) without using the command line.
 
 Contact us by emailing [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) if you have any questions.
 
@@ -24,13 +26,19 @@ GOV.UK PaaS is hosted on [Cloud Foundry](https://www.cloudfoundry.org/) [externa
 
     Depending on your network configuration, you might need to set an [`HTTP_PROXY` environment variable](https://docs.cloudfoundry.org/cf-cli/http-proxy.html) [external link] for the CLI to connect. Contact your network administrator for your configuration settings.
 
-3. Sign in to Cloud Foundry by running:
+3. Sign in to Cloud Foundry. If your org is hosted on the London-based GOV.UK PaaS, run:
+
+    ```
+    cf login -a api.london.cloud.service.gov.uk -u USERNAME
+    ```
+
+    If your org is hosted on the Ireland-based GOV.UK PaaS, run:
 
     ```
     cf login -a api.cloud.service.gov.uk -u USERNAME
     ```
 
-    where `USERNAME` is your individual account email address.
+    `USERNAME` is your individual account email address.
 
 4. Enter your password (you set this password when you clicked on the invite link in your welcome email).
 

--- a/source/documentation/getting_started/get_started.md
+++ b/source/documentation/getting_started/get_started.md
@@ -6,7 +6,7 @@ Your department, agency or team must have a GOV.UK PaaS account. This account is
 
 Once your department, agency or team has an org account, you will need a personal account. Ask your [org manager](orgs_spaces_users.html#org-manager) to authorise the creation of your personal account.
 
-The GOV.UK PaaS is hosted in two regions, London and Ireland. The GOV.UK PaaS team creates all new orgs in the London region by default. If you already have an account in the Ireland region and request a new org, we will create this new org and account in the London region, and you will have two separate accounts
+The GOV.UK PaaS is hosted in two independent regions, London and Ireland. The GOV.UK PaaS team creates new accounts in the London region unless you request otherwise. 
 
 To provide you with an account, we need to store some personal data about you. Please see our [privacy notice](https://www.cloud.service.gov.uk/privacy-notice) for details.
 
@@ -26,13 +26,13 @@ GOV.UK PaaS is hosted on [Cloud Foundry](https://www.cloudfoundry.org/) [externa
 
     Depending on your network configuration, you might need to set an [`HTTP_PROXY` environment variable](https://docs.cloudfoundry.org/cf-cli/http-proxy.html) [external link] for the CLI to connect. Contact your network administrator for your configuration settings.
 
-3. Sign in to Cloud Foundry. If your org is hosted on the London region, run:
+3. Sign in to Cloud Foundry. If your org is hosted in the London region, run:
 
     ```
     cf login -a api.london.cloud.service.gov.uk -u USERNAME
     ```
 
-    If your org is hosted on the Ireland region, run:
+    If your org is hosted in the Ireland region, run:
 
     ```
     cf login -a api.cloud.service.gov.uk -u USERNAME

--- a/source/documentation/getting_started/get_started.md
+++ b/source/documentation/getting_started/get_started.md
@@ -6,7 +6,7 @@ Your department, agency or team must have a GOV.UK PaaS account. This account is
 
 Once your department, agency or team has an org account, you will need a personal account. Ask your [org manager](orgs_spaces_users.html#org-manager) to authorise the creation of your personal account.
 
-The GOV.UK PaaS is hosted in two regions, London and Ireland. The GOV.UK PaaS team creates all new orgs on the London-based GOV.UK PaaS by default. If you already have an account on the Ireland-based GOV.UK PaaS and request a new org, we will create this new org and account on the London-based GOV.UK PaaS, and you will have two separate accounts.
+The GOV.UK PaaS is hosted in two regions, London and Ireland. The GOV.UK PaaS team creates all new orgs in the London region by default. If you already have an account in the Ireland region and request a new org, we will create this new org and account in the London region, and you will have two separate accounts
 
 To provide you with an account, we need to store some personal data about you. Please see our [privacy notice](https://www.cloud.service.gov.uk/privacy-notice) for details.
 

--- a/source/documentation/index.md
+++ b/source/documentation/index.md
@@ -2,6 +2,8 @@
 
 GOV.UK Platform as a Service (PaaS) is a cloud-hosting platform built by the Government Digital Service (GDS). GOV.UK PaaS manages the deployment of your apps, services and background tasks so you don’t need to hire people with specialist cloud skills.
 
+The GOV.UK PaaS is hosted in two locations, London and Ireland. 
+
 GOV.UK PaaS is currently in private beta.
 
 GOV.UK PaaS uses the open source [Cloud Foundry](https://www.cloudfoundry.org/) [external link] project, and runs on Amazon Web Services. [Read our blog post](https://governmentasaplatform.blog.gov.uk/2015/12/17/choosing-cloudfoundry/) [external link] for more information on why we chose Cloud Foundry. Refer to the [features page](https://www.cloud.service.gov.uk/features) for more information on GOV.UK PaaS.

--- a/source/documentation/index.md
+++ b/source/documentation/index.md
@@ -2,7 +2,7 @@
 
 GOV.UK Platform as a Service (PaaS) is a cloud-hosting platform built by the Government Digital Service (GDS). GOV.UK PaaS manages the deployment of your apps, services and background tasks so you don’t need to hire people with specialist cloud skills.
 
-The GOV.UK PaaS is hosted in two locations, London and Ireland. 
+The GOV.UK PaaS is hosted in two regions, London and Ireland. 
 
 GOV.UK PaaS is currently in private beta.
 

--- a/source/documentation/monitoring_apps/metrics.md
+++ b/source/documentation/monitoring_apps/metrics.md
@@ -11,9 +11,14 @@ You can also view all metrics in a one-off snapshot by installing the Cloud Foun
 
 ### Use the Prometheus endpoint
 
-Prometheus uses the `https://metrics.cloud.service.gov.uk/metrics` API endpoint to request metrics from Cloud Foundry. PaaS maintains this endpoint for free, so you can access all available metrics for free. You can configure Prometheus manually to filter out any metrics you do not need.
+Prometheus uses the following API endpoints to request metrics from Cloud Foundry:
 
-You must set up Prometheus to request metrics from the `https://metrics.cloud.service.gov.uk/metrics` API endpoint.
+- `https://metrics.cloud.service.gov.uk/metrics` for the Ireland region
+- `https://metrics.london.cloud.service.gov.uk/metrics` for the London region
+
+PaaS maintains these endpoints for free, so you can access all available metrics for free. You can configure Prometheus manually to filter out any metrics you do not need.
+
+You must set up Prometheus to request metrics from your region's API endpoint.
 
 1. [Install Prometheus](https://prometheus.io/docs/prometheus/latest/getting_started/) [external link].
 
@@ -31,7 +36,7 @@ You must set up Prometheus to request metrics from the `https://metrics.cloud.se
 
 #### Use Docker to run Prometheus locally
 
-You can set up Prometheus to request metrics from the API endpoint by using [Docker](https://www.docker.com/) [external link] to run a local instance of Prometheus.
+You can set up Prometheus to request metrics from your region's API endpoint by using [Docker](https://www.docker.com/) [external link] to run a local instance of Prometheus.
 
 1. Save the following script as `test-metrics.sh`:
 
@@ -51,13 +56,16 @@ You can set up Prometheus to request metrics from the API endpoint by using [Doc
 	    scheme: https
 	    static_configs:
 	      - targets:
-	        - metrics.cloud.service.gov.uk:443
+	        - API_ENDPOINT:443
 	" > prometheus.yml
 
 	docker run --publish 9090:9090 \
 	           --volume "$PWD/prometheus.yml:/etc/prometheus/prometheus.yml" \
 	           prom/prometheus
 	```
+	where API_ENDPOINT is:
+	- `https://metrics.cloud.service.gov.uk/metrics` for the Ireland region
+	- `https://metrics.london.cloud.service.gov.uk/metrics` for the London region
 
 1. Make the script executable:
 
@@ -112,7 +120,7 @@ To set up the metrics exporter app:
 
 	|Name|Value|
 	|:---|:---|
-	|`API_ENDPOINT`|Use `https://api.cloud.service.gov.uk`|
+	|`API_ENDPOINT`|- `https://api.cloud.service.gov.uk` for Ireland<br>- `https://api.london.cloud.service.gov.uk` for London|
 	|`STATSD_ENDPOINT`|StatsD endpoint|
 	|`USERNAME`|Cloud Foundry User|
 	|`PASSWORD`|Cloud Foundry Password|

--- a/source/documentation/orgs_spaces_users/index.md
+++ b/source/documentation/orgs_spaces_users/index.md
@@ -1,12 +1,18 @@
 # Managing organisations, spaces and users
 
+## Regions
+
+The GOV.UK PaaS is hosted in two independent regions, London and Ireland.
+
+GOV.UK PaaS accounts, credentials and resources (for example [backing services](/deploying_services/)) are created in a single region.
+
 ## Organisations
 
 An organisation, or org, represents a group of users, applications and environments. Each org shares the same resource, quota and custom domain.
 
-The GOV.UK PaaS team creates the first org for a new project, and assigns at least one [org manager](orgs_spaces_users.html#org-manager) to that org. If you want to start a new project on the GOV.UK PaaS, contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk), telling us who the org manager(s) should be.
+The GOV.UK PaaS team creates new orgs in the London region unless you request otherwise. We assign at least one [org manager](orgs_spaces_users.html#org-manager) to new orgs. Request your first org on the [GOV.UK PaaS signup page](https://www.cloud.service.gov.uk/signup).
 
-The GOV.UK PaaS is hosted in two regions, London and Ireland. The GOV.UK PaaS team creates all new orgs in the London region by default. If you already have an account in the Ireland region and request a new org, we will create this new org and account in the London region, and you will have two separate accounts.    
+To request additional orgs, contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk), telling us who the org manager(s) should be and the name of one of your existing orgs.
 
 Run `cf orgs` to list the orgs your user account can access.
 

--- a/source/documentation/orgs_spaces_users/index.md
+++ b/source/documentation/orgs_spaces_users/index.md
@@ -4,28 +4,28 @@
 
 An organisation, or org, represents a group of users, applications and environments. Each org shares the same resource, quota and custom domain.
 
-The GOV.UK PaaS team creates the first org for a new project, and assigns at least 1 [org manager](orgs_spaces_users.html#org-manager) to that org. If you want to start a new project on the GOV.UK PaaS, contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk), telling us who the org manager(s) should be.
+The GOV.UK PaaS team creates the first org for a new project, and assigns at least one [org manager](orgs_spaces_users.html#org-manager) to that org. If you want to start a new project on the GOV.UK PaaS, contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk), telling us who the org manager(s) should be.
 
-The GOV.UK PaaS is hosted in two locations, London and Ireland. The GOV.UK PaaS team creates all new orgs on the London-based GOV.UK PaaS by default. If you already have an account on the Ireland-based GOV.UK PaaS and request a new org, we will create this new org and account on the London-based GOV.UK PaaS, and you will have two separate accounts.    
+The GOV.UK PaaS is hosted in two regions, London and Ireland. The GOV.UK PaaS team creates all new orgs in the London region by default. If you already have an account in the Ireland region and request a new org, we will create this new org and account in the London region, and you will have two separate accounts.    
 
 Run `cf orgs` to list the orgs your user account can access.
 
-To see [quota](managing_apps.html#quotas) information about an org, you can select the appropriate org in either the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool (requires sign in), and check the __Memory__ total in the top right corner of the screen. The amount of information you can see depends on your user role within the org. For example, org managers can see all quota information, whereas space developers can only see information on spaces that they are members of.
+To see [quota](managing_apps.html#quotas) information about an org, you can select the appropriate org using the GOV.UK PaaS admin tool for [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/) (requires sign in), and check the __Memory__ total in the top right corner of the screen. The amount of information you can see depends on your user role within the org. For example, org managers can see all quota information, whereas space developers can only see information on spaces that they are members of.
 
 You can also run `cf org ORGNAME` to see [quota](managing_apps.html#quotas) information about an org, where `ORGNAME` is the name of the org.
 
-Your user account will be initially assigned to 1 org by the PaaS team and then you can choose to belong to additional orgs. You can contact [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) to request more orgs.
+Your user account will be initially assigned to one org by the PaaS team and then you can choose to belong to additional orgs. You can contact [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) to request more orgs.
 
 ## Spaces
 
-An org is divided into 1 or more spaces. A space is a shared location for developing, deploying and running apps and backing services.
+An org is divided into one or more spaces. A space is a shared location for developing, deploying and running apps and backing services.
 
 For example, you might have separate spaces for the development and production versions of your app. When we set up your org, we create a default sandbox space you can use for experimenting with the PaaS.
 
 To see the spaces you can access in your current org, you can either:
 
 - run `cf spaces` in the command line
-- sign into either the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool and select the appropriate org
+- sign into the GOV.UK PaaS admin tool for either [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/) and select the appropriate org
 
 [Org managers](orgs_spaces_users.html#org-manager) can create new spaces within an org.
 
@@ -39,7 +39,7 @@ Users are members of your team who can access or manage apps and backing service
 
 Users are assigned roles which have different permissions for accessing and managing orgs and spaces. A user can have one or multiple roles within the same or different orgs and spaces.
 
-To see a list of users and their roles in your org, you can select the Members screen for the appropriate org in either the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool (requires sign in). Your user account must have the [org manager role](orgs_spaces_users.html#org-manager) or the [org auditor role](orgs_spaces_users.html#org-auditor) to see this information in the admin tool.
+To see a list of users and their roles in your org, you can view the appropriate org's __Members__ screen in the GOV.UK PaaS admin tool for either [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/) (requires sign in). Your user account must have the [org manager role](orgs_spaces_users.html#org-manager) or the [org auditor role](orgs_spaces_users.html#org-auditor) to see this information in the admin tool.
 
 You can also run `cf org-users ORGNAME` to see a list of users and their roles in your org, where `ORGNAME` is the name of the org.
 
@@ -58,13 +58,13 @@ Refer to the [Cloud Foundry documentation on roles and permissions](https://docs
 
 This role applies within an org.
 
-Every org must have at least 1 org manager. Org managers are primary contacts for the org.
+Every org must have at least one org manager. Org managers are primary contacts for the org.
 
 Org managers manage spaces, users and user roles, and approve org changes such as requesting new quotas and enabling paid services.
 
-Org managers can invite new users to an org using either the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool (requires sign in) without needing to contact the GOV.UK PaaS team.
+Org managers can invite new users to an org using the GOV.UK PaaS admin tool for either [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/) (requires sign in) without needing to contact the GOV.UK PaaS team.
 
-We create at least 1 user account with the org manager role as part of your onboarding process. We recommend you have at least 2 org managers in case 1 is unavailable.
+We create at least one user account with the org manager role as part of your onboarding process. We recommend you have at least 2 org managers in case one is unavailable.
 
 If you need the org manager role added to a user account, contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
 
@@ -78,7 +78,7 @@ Org auditors can view user account information and org [quota](managing_apps.htm
 
 This role applies within an org.
 
-Billing managers create and manage billing account and payment information. They can also view users and roles using either the command line, the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool (requires sign in).
+Billing managers create and manage billing account and payment information. They can also view users and roles using either the command line, the GOV.UK PaaS admin tool for [London](https://admin.london.cloud.service.gov.uk/) or the admin tool for [Ireland](https://admin.cloud.service.gov.uk/) (requires sign in).
 
 You should assign a billing manager to your org before your service moves to production. We will send all payment requests to the billing manager. An org manager can also be a billing manager.
 
@@ -126,9 +126,9 @@ You can then add users to that space.
 
 ### Add users to a space
 
-After a user has been added to an org, org managers can use the [GOV.UK PaaS admin tool](https://admin.cloud.service.gov.uk/) (requires sign in) to grant a user access to a space by assigning a role to that user.
+After a user has been added to an org, org managers can use the GOV.UK PaaS admin tool for [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/) (requires sign in) to grant a user access to a space by assigning a role to that user.
 
-1. Sign into either the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool.
+1. Sign into the GOV.UK PaaS admin tool for either [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/).
 1. Select the appropriate org.
 1. Select __View and manage team members__.
 1. Select __Invite a new team member__.
@@ -162,7 +162,7 @@ When a team member leaves or stops working on a project, the org manager should 
 
 The org manager can use the GOV.UK PaaS admin tool to remove all of the team member’s user roles within the team’s spaces.
 
-1. Sign into either the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool.
+1. Sign into the GOV.UK PaaS admin tool for either [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/).
 1. Select the appropriate org.
 1. Select __View and manage team members__.
 1. Select the appropriate user.
@@ -193,7 +193,7 @@ Refer to the [Cloud Foundry reference guide on `cf unset-space-role`](https://cl
 
 Org managers can use the GOV.UK PaaS admin tool to invite users to their org when they join their team.
 
-1. Sign into either the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool.
+1. Sign into the GOV.UK PaaS admin tool for either [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/).
 1. Select the appropriate org.
 1. Select __View and manage team members__.
 1. Select __Invite a new team member__.
@@ -205,7 +205,7 @@ When a team member leaves or stops working on a project, their org manager must 
 
 If the leaving team member has an org role such as org manager or billing manager, either the other org manager or the GOV.UK PaaS team must also remove that team member’s user role from the team’s org.
 
-1. Sign into either the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool.
+1. Sign into the GOV.UK PaaS admin tool for either [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/).
 1. Select the appropriate org.
 1. Select __View and manage team members__.
 1. Select the appropriate user.
@@ -240,7 +240,7 @@ Refer to the [Cloud Foundry documentation on creating and managing users with th
 
 [Org managers](/orgs_spaces_users.html#org-manager) and [billing managers](/orgs_spaces_users.html#billing-manager) can use the GOV.UK PaaS admin tool to view current or past bills within an org.
 
-1. Sign into either the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool.
+1. Sign into the GOV.UK PaaS admin tool for either [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/).
 1. Select the appropriate org.
 1. Select __Billing__.
 1. View your bills. You can filter the bills shown by __Month__, __Space__, or __Services and apps__.

--- a/source/documentation/orgs_spaces_users/index.md
+++ b/source/documentation/orgs_spaces_users/index.md
@@ -2,17 +2,17 @@
 
 ## Regions
 
-The GOV.UK PaaS is hosted in two independent regions, London and Ireland.
+The GOV.UK PaaS is hosted in 2 independent regions, London and Ireland.
 
-GOV.UK PaaS accounts, credentials and resources (for example [backing services](/deploying_services/)) are created in a single region.
+GOV.UK PaaS accounts, credentials and resources are created in a single region. For example, [backing services](/deploying_services/). 
 
 ## Organisations
 
 An organisation, or org, represents a group of users, applications and environments. Each org shares the same resource, quota and custom domain.
 
-The GOV.UK PaaS team creates new orgs in the London region unless you request otherwise. We assign at least one [org manager](orgs_spaces_users.html#org-manager) to new orgs. Request your first org on the [GOV.UK PaaS signup page](https://www.cloud.service.gov.uk/signup).
+The GOV.UK PaaS team creates new orgs in the London region unless you request otherwise. We assign at least one [org manager](orgs_spaces_users.html#org-manager) to new orgs. You can request your first org on the [GOV.UK PaaS signup page](https://www.cloud.service.gov.uk/signup).
 
-To request additional orgs, contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk), telling us who the org manager(s) should be and the name of one of your existing orgs.
+To request additional orgs, contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) and tell us who the org manager(s) should be and the name of one of your existing orgs.
 
 Run `cf orgs` to list the orgs your user account can access.
 
@@ -31,7 +31,7 @@ For example, you might have separate spaces for the development and production v
 To see the spaces you can access in your current org, you can either:
 
 - run `cf spaces` in the command line
-- sign into the GOV.UK PaaS admin tool for either [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/) and select the appropriate org
+- sign in to the GOV.UK PaaS admin tool for either [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/) and select the appropriate org
 
 [Org managers](orgs_spaces_users.html#org-manager) can create new spaces within an org.
 
@@ -68,7 +68,7 @@ Every org must have at least one org manager. Org managers are primary contacts 
 
 Org managers manage spaces, users and user roles, and approve org changes such as requesting new quotas and enabling paid services.
 
-Org managers can invite new users to an org using the GOV.UK PaaS admin tool for either [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/) (requires sign in) without needing to contact the GOV.UK PaaS team.
+Org managers can use the GOV.UK PaaS admin tool to invite new users to an org, without needing to contact the GOV.UK PaaS team. This is possible for either [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/) (requires sign in).
 
 We create at least one user account with the org manager role as part of your onboarding process. We recommend you have at least 2 org managers in case one is unavailable.
 
@@ -84,7 +84,7 @@ Org auditors can view user account information and org [quota](managing_apps.htm
 
 This role applies within an org.
 
-Billing managers create and manage billing account and payment information. They can also view users and roles using either the command line, the GOV.UK PaaS admin tool for [London](https://admin.london.cloud.service.gov.uk/) or the admin tool for [Ireland](https://admin.cloud.service.gov.uk/) (requires sign in).
+Billing managers create and manage billing account and payment information. They can also view users and roles using the command line, or the GOV.UK PaaS admin tool for either the [London](https://admin.london.cloud.service.gov.uk/) or the [Ireland](https://admin.cloud.service.gov.uk/) region (requires sign in).
 
 You should assign a billing manager to your org before your service moves to production. We will send all payment requests to the billing manager. An org manager can also be a billing manager.
 
@@ -134,7 +134,7 @@ You can then add users to that space.
 
 After a user has been added to an org, org managers can use the GOV.UK PaaS admin tool for [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/) (requires sign in) to grant a user access to a space by assigning a role to that user.
 
-1. Sign into the GOV.UK PaaS admin tool for either [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/).
+1. Sign in to the GOV.UK PaaS admin tool for either [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/).
 1. Select the appropriate org.
 1. Select __View and manage team members__.
 1. Select __Invite a new team member__.
@@ -168,7 +168,7 @@ When a team member leaves or stops working on a project, the org manager should 
 
 The org manager can use the GOV.UK PaaS admin tool to remove all of the team member’s user roles within the team’s spaces.
 
-1. Sign into the GOV.UK PaaS admin tool for either [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/).
+1. Sign in to the GOV.UK PaaS admin tool for either [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/).
 1. Select the appropriate org.
 1. Select __View and manage team members__.
 1. Select the appropriate user.
@@ -199,7 +199,7 @@ Refer to the [Cloud Foundry reference guide on `cf unset-space-role`](https://cl
 
 Org managers can use the GOV.UK PaaS admin tool to invite users to their org when they join their team.
 
-1. Sign into the GOV.UK PaaS admin tool for either [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/).
+1. Sign in to the GOV.UK PaaS admin tool for either [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/).
 1. Select the appropriate org.
 1. Select __View and manage team members__.
 1. Select __Invite a new team member__.
@@ -211,7 +211,7 @@ When a team member leaves or stops working on a project, their org manager must 
 
 If the leaving team member has an org role such as org manager or billing manager, either the other org manager or the GOV.UK PaaS team must also remove that team member’s user role from the team’s org.
 
-1. Sign into the GOV.UK PaaS admin tool for either [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/).
+1. Sign in to the GOV.UK PaaS admin tool for either [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/).
 1. Select the appropriate org.
 1. Select __View and manage team members__.
 1. Select the appropriate user.
@@ -246,7 +246,7 @@ Refer to the [Cloud Foundry documentation on creating and managing users with th
 
 [Org managers](/orgs_spaces_users.html#org-manager) and [billing managers](/orgs_spaces_users.html#billing-manager) can use the GOV.UK PaaS admin tool to view current or past bills within an org.
 
-1. Sign into the GOV.UK PaaS admin tool for either [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/).
+1. Sign in to the GOV.UK PaaS admin tool for either [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/).
 1. Select the appropriate org.
 1. Select __Billing__.
 1. View your bills. You can filter the bills shown by __Month__, __Space__, or __Services and apps__.

--- a/source/documentation/orgs_spaces_users/index.md
+++ b/source/documentation/orgs_spaces_users/index.md
@@ -4,16 +4,17 @@
 
 An organisation, or org, represents a group of users, applications and environments. Each org shares the same resource, quota and custom domain.
 
-The PaaS team creates the first org for a new project, and assigns at least 1 [org manager](orgs_spaces_users.html#org-manager) to that org. If you want to start a new project on the GOV.UK PaaS, contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk), telling us who the org manager(s) should be.
+The GOV.UK PaaS team creates the first org for a new project, and assigns at least 1 [org manager](orgs_spaces_users.html#org-manager) to that org. If you want to start a new project on the GOV.UK PaaS, contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk), telling us who the org manager(s) should be.
+
+The GOV.UK PaaS is hosted in two locations, London and Ireland. The GOV.UK PaaS team creates all new orgs on the London-based GOV.UK PaaS by default. If you already have an account on the Ireland-based GOV.UK PaaS and request a new org, we will create this new org and account on the London-based GOV.UK PaaS, and you will have two separate accounts.    
 
 Run `cf orgs` to list the orgs your user account can access.
 
-To see [quota](managing_apps.html#quotas) information about an org, you can select the appropriate org in the [GOV.UK PaaS admin tool](https://admin.cloud.service.gov.uk/) (requires sign in) and check the __Memory__ total in the top right corner of the screen. The amount of information you can see depends on your user role within the org. For example, org managers can see all quota information, whereas space developers can only see information on spaces that they are members of.
+To see [quota](managing_apps.html#quotas) information about an org, you can select the appropriate org in either the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool (requires sign in), and check the __Memory__ total in the top right corner of the screen. The amount of information you can see depends on your user role within the org. For example, org managers can see all quota information, whereas space developers can only see information on spaces that they are members of.
 
 You can also run `cf org ORGNAME` to see [quota](managing_apps.html#quotas) information about an org, where `ORGNAME` is the name of the org.
 
 Your user account will be initially assigned to 1 org by the PaaS team and then you can choose to belong to additional orgs. You can contact [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) to request more orgs.
-
 
 ## Spaces
 
@@ -24,7 +25,7 @@ For example, you might have separate spaces for the development and production v
 To see the spaces you can access in your current org, you can either:
 
 - run `cf spaces` in the command line
-- sign into the [GOV.UK PaaS admin tool](https://admin.cloud.service.gov.uk/) and select the appropriate org
+- sign into either the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool and select the appropriate org
 
 [Org managers](orgs_spaces_users.html#org-manager) can create new spaces within an org.
 
@@ -38,7 +39,7 @@ Users are members of your team who can access or manage apps and backing service
 
 Users are assigned roles which have different permissions for accessing and managing orgs and spaces. A user can have one or multiple roles within the same or different orgs and spaces.
 
-To see a list of users and their roles in your org, you can select the Members screen for the appropriate org in the [GOV.UK PaaS admin tool](https://admin.cloud.service.gov.uk/) (requires sign in). Your user account must have the [org manager role](orgs_spaces_users.html#org-manager) or the [org auditor role](orgs_spaces_users.html#org-auditor) to see this information in the admin tool.
+To see a list of users and their roles in your org, you can select the Members screen for the appropriate org in either the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool (requires sign in). Your user account must have the [org manager role](orgs_spaces_users.html#org-manager) or the [org auditor role](orgs_spaces_users.html#org-auditor) to see this information in the admin tool.
 
 You can also run `cf org-users ORGNAME` to see a list of users and their roles in your org, where `ORGNAME` is the name of the org.
 
@@ -61,7 +62,7 @@ Every org must have at least 1 org manager. Org managers are primary contacts fo
 
 Org managers manage spaces, users and user roles, and approve org changes such as requesting new quotas and enabling paid services.
 
-Org managers can invite new users to an org using the [GOV.UK PaaS admin tool](https://admin.cloud.service.gov.uk/) (requires sign in) without needing to contact the GOV.UK PaaS team.
+Org managers can invite new users to an org using either the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool (requires sign in) without needing to contact the GOV.UK PaaS team.
 
 We create at least 1 user account with the org manager role as part of your onboarding process. We recommend you have at least 2 org managers in case 1 is unavailable.
 
@@ -77,7 +78,7 @@ Org auditors can view user account information and org [quota](managing_apps.htm
 
 This role applies within an org.
 
-Billing managers create and manage billing account and payment information. They can also view users and roles using either the command line or the [GOV.UK PaaS admin tool](https://admin.cloud.service.gov.uk/) (requires sign in).
+Billing managers create and manage billing account and payment information. They can also view users and roles using either the command line, the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool (requires sign in).
 
 You should assign a billing manager to your org before your service moves to production. We will send all payment requests to the billing manager. An org manager can also be a billing manager.
 
@@ -127,7 +128,7 @@ You can then add users to that space.
 
 After a user has been added to an org, org managers can use the [GOV.UK PaaS admin tool](https://admin.cloud.service.gov.uk/) (requires sign in) to grant a user access to a space by assigning a role to that user.
 
-1. Sign into the [GOV.UK PaaS admin tool](https://admin.cloud.service.gov.uk/).
+1. Sign into either the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool.
 1. Select the appropriate org.
 1. Select __View and manage team members__.
 1. Select __Invite a new team member__.
@@ -161,12 +162,11 @@ When a team member leaves or stops working on a project, the org manager should 
 
 The org manager can use the GOV.UK PaaS admin tool to remove all of the team member’s user roles within the team’s spaces.
 
-1. Sign into the [GOV.UK PaaS admin tool](https://admin.cloud.service.gov.uk/).
+1. Sign into either the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool.
 1. Select the appropriate org.
 1. Select __View and manage team members__.
 1. Select the appropriate user.
 1. Change the user’s space roles and select __Save role changes__.
-
 
 Alternatively, the org manager can run the following in the command line:
 
@@ -193,7 +193,7 @@ Refer to the [Cloud Foundry reference guide on `cf unset-space-role`](https://cl
 
 Org managers can use the GOV.UK PaaS admin tool to invite users to their org when they join their team.
 
-1. Sign into the [GOV.UK PaaS admin tool](https://admin.cloud.service.gov.uk).
+1. Sign into either the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool.
 1. Select the appropriate org.
 1. Select __View and manage team members__.
 1. Select __Invite a new team member__.
@@ -205,7 +205,7 @@ When a team member leaves or stops working on a project, their org manager must 
 
 If the leaving team member has an org role such as org manager or billing manager, either the other org manager or the GOV.UK PaaS team must also remove that team member’s user role from the team’s org.
 
-1. Sign into the [GOV.UK PaaS admin tool](https://admin.cloud.service.gov.uk).
+1. Sign into either the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool.
 1. Select the appropriate org.
 1. Select __View and manage team members__.
 1. Select the appropriate user.
@@ -240,7 +240,7 @@ Refer to the [Cloud Foundry documentation on creating and managing users with th
 
 [Org managers](/orgs_spaces_users.html#org-manager) and [billing managers](/orgs_spaces_users.html#billing-manager) can use the GOV.UK PaaS admin tool to view current or past bills within an org.
 
-1. Sign into the [GOV.UK PaaS admin tool](https://admin.cloud.service.gov.uk).
+1. Sign into either the [London-based](http://admin.london.cloud.service.gov.uk/) or the [Ireland-based](http://admin.cloud.service.gov.uk/) GOV.UK PaaS admin tool.
 1. Select the appropriate org.
 1. Select __Billing__.
 1. View your bills. You can filter the bills shown by __Month__, __Space__, or __Services and apps__.

--- a/source/documentation/using_ci/jenkins.md
+++ b/source/documentation/using_ci/jenkins.md
@@ -57,7 +57,9 @@ A basic 'execute shell' buildstep would look like this:
 export CF_HOME="$(mktemp -d)"
 trap 'rm -r $CF_HOME' EXIT
 
-cf api https://api.cloud.service.gov.uk
+cf api API_ENDPOINT
+# https://api.cloud.service.gov.uk for the Ireland region
+# https://api.london.cloud.service.gov.uk for the London region
 
 # Note: the actual name of the environment variable is determined
 # by what you enter into the Credentials Binding Plugin
@@ -84,7 +86,7 @@ To install the Cloud Foundry plugin manually:
 An extra post-build action called "Push to Cloud Foundry" is now available in the dropdown menu when you configure a job.
 
 1. In your job's configuration, click the **Add post-build action** dropdown menu and select **Push to Cloud Foundry**.
-2. In the **Target** field, enter `https://api.cloud.service.gov.uk`.
+2. In the **Target** field, enter either `https://api.cloud.service.gov.uk` for the Ireland region, or `https://api.london.cloud.service.gov.uk` for the London region.
 3. In **Credentials**, select the user you created using the credentials plugin.
 4. Enter your organisation and the space the application will be deployed to. See [Managing orgs, spaces and users](/orgs_spaces_users.html#managing-organisations-spaces-and-users) for more details about organisations and spaces. You do not need to tick "Allow self-signed certificate" or "Reset app if already exists".
 5. The rest of the fields can be left with their default values. The plugin expects you to have a manifest file called `manifest.yml` in the root of the application folder. If you do not, you can provide the path to the application manifest, or enter a manifest configuration directly into the plugin.

--- a/source/documentation/using_ci/travis.md
+++ b/source/documentation/using_ci/travis.md
@@ -32,7 +32,7 @@ Before setting up Travis CI, you must have:
 1. Input the following information when asked:
     - [account](/using_ci.html#configure-your-ci-tool-accounts) username and password
     - the [space](/orgs_spaces_users.html#spaces) and [organisation](/orgs_spaces_users.html#organisations) to deploy your app to
-    - the API URL: `https://api.cloud.service.gov.uk`
+    - the API endpoint URL: `https://api.cloud.service.gov.uk` for the Ireland region, or `https://api.london.cloud.service.gov.uk` for the London region
 
 Travis CI encrypts this information into a `.travis.yml` file.
 
@@ -49,7 +49,7 @@ You can now [build and deploy the app](using_ci.html#build-and-deploy-the-app).
       edge: true
       provider: cloudfoundry
       username: USERNAME
-      api: https://api.cloud.service.gov.uk
+      api: API_ENDPOINT
       organization: ORGNAME
       space: SPACENAME
     ```


### PR DESCRIPTION
What
----

Updated tech docs to reflect that the PaaS is now hosted in two locations, London and Ireland:
- Added how to log into both London and Ireland
- Added that a user will have two accounts if they belong to orgs in both London and Ireland
- Added how to log into the London and Ireland admin tools separately

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Check that it fulfils https://www.pivotaltracker.com/story/show/159073525

Who can review
--------------

Anyone except Jon Glassman