### PR TITLE
document how to set JRE version using env var

### DIFF
--- a/source/documentation/deploying_apps/deploying_java.md
+++ b/source/documentation/deploying_apps/deploying_java.md
@@ -112,9 +112,7 @@ You can specify the version of the Java Runtime Environment (JRE) by setting the
   env:
     JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 11.+ } }'
  ```
-The `+` in the above example acts as a wildcard which will use the latest point release available.
-
-To see if a JRE version is available you can check this [version list](http://download.pivotal.io.s3.amazonaws.com/openjdk/trusty/x86_64/index.yml) [external link]. 
+The `+` in the above example acts as a wildcard which will use the latest point release available. 
 
 ### Deploying other JVM-based applications
 

--- a/source/documentation/deploying_apps/deploying_java.md
+++ b/source/documentation/deploying_apps/deploying_java.md
@@ -112,7 +112,7 @@ You can specify the version of the Java Runtime Environment (JRE) by setting the
   env:
     JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 11.+ } }'
  ```
-The `+` in the above example acts as a wildcard which will use the latest point release available. 
+The `+` in this example means it will use the latest point release available.
 
 ### Deploying other JVM-based applications
 

--- a/source/documentation/deploying_apps/deploying_java.md
+++ b/source/documentation/deploying_apps/deploying_java.md
@@ -106,7 +106,7 @@ For more configuration options see [Tomcat Container](https://github.com/cloudfo
 
 ### Specify a Java version
 
-You can specify the version of the Java Runtime Environment (JRE) by setting the environment variable `JBP_CONFIG_OPEN_JDK_JRE`. For example to use JRE 11 you could add the following to your application's `manifest.yml`:
+You can specify the version of the Java Runtime Environment (JRE) by setting the environment variable `JBP_CONFIG_OPEN_JDK_JRE` in the application's `manifest.yml`. For example, to use JRE 11:
 
 ```yaml
   env:

--- a/source/documentation/deploying_apps/deploying_java.md
+++ b/source/documentation/deploying_apps/deploying_java.md
@@ -106,11 +106,15 @@ For more configuration options see [Tomcat Container](https://github.com/cloudfo
 
 ### Specify a Java version
 
-You should tell Cloud Foundry which version of Java your app uses in the Java buildpack.
+You can specify the version of the Java Runtime Environment (JRE) by setting the environment variable `JBP_CONFIG_OPEN_JDK_JRE`. For example to use JRE 11 you could add the following to your application's `manifest.yml`:
 
-Refer to the documentation on [buildpack language version updates](deploying_apps.html#buildpack-language-version-updates) for more information.
+```yaml
+  env:
+    JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 11.+ } }'
+ ```
+The `+` in the above example acts as a wildcard which will use the latest point release available.
 
-Refer to the Cloud Foundry OpenJDK JRE documentation for more information on [the Java buildpack](https://github.com/cloudfoundry/java-buildpack/blob/master/docs/jre-open_jdk_jre.md) [external link].
+To see if a JRE version is available you can check this [version list](http://download.pivotal.io.s3.amazonaws.com/openjdk/trusty/x86_64/index.yml) [external link]. 
 
 ### Deploying other JVM-based applications
 


### PR DESCRIPTION
What
----
The previous text had some information under the heading *Specify a Java Version* about checking the buildpack version which is irrelevant to specifying the Java version!
  
Judging by my own experience and others on Slack this information was not helpful and is arguably harmful in sending people further away from the expected answer.

I have changed the text to reflect the required steps to set the JRE version.

How to review
-------------

Describe the steps required to test the changes.

run locally and go to: `/deploying_apps.html#specify-a-java-version`

Who can review
--------------
anyone but me. CC @richardTowers 