### PR TITLE
Automatic http->https redirection is only for public routes

### DIFF
--- a/source/documentation/deploying_apps/index.md
+++ b/source/documentation/deploying_apps/index.md
@@ -182,9 +182,9 @@ Refer to the [GOV.UK page on government security classifications](https://www.go
 
 ## Secure and non-secure requests
 
-Requests could be made to the non-secure `http://` protocol due to:
+Requests could be made to an app's public route over the non-secure `http://` protocol due to:
 
  * misconfiguration of an app that allows non-encrypted traffic through
  * a service linking to the HTTP version of a page by mistake
 
-In this situation, any requests made to the `http://` protocol will be automatically redirected to the base HTTPS version of that URL. The original query path and query parameters will be removed. This prevents a site from repeatedly redirecting back to the HTTP protocol without the user noticing.
+Any requests made to a public app route over the `http://` protocol will be automatically redirected to the base `https://` version of that URL. The original query path and query parameters will be removed. This prevents a site from repeatedly redirecting back to the HTTP protocol without the user noticing.


### PR DESCRIPTION
What
----

After the launch/announcement of private apps, the section on http->https redirection needs scoping to non-private apps.

This is because the redirection is done at the PaaS border, an interface which app-to-private-app traffic doesn't traverse.

How to review
-------------

- PaaS Dev/Ops: read and agree/comment
- Tech writer: agree that this change doesn't require 2i, or push it into that process as appropriate.

Who can review
--------------

Anyone except @jpluscplusm, but it must have @jonathanglassman's approval before merging.