### PR TITLE
Add in content for rebooting a PostgreSQL or MySQL service instance

### DIFF
--- a/source/documentation/deploying_services/mysql.md
+++ b/source/documentation/deploying_services/mysql.md
@@ -239,7 +239,7 @@ You can [reboot](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Reb
 - try to fix a problem with your service instance
 - test how your app behaves during a service instance failure
 
-To reboot your service instance, you must have [space developer](/orgs_spaces_users.html#space-developer) permissions in the [space](/orgs_spaces_users.html#spaces) that hosts your service instance.
+To reboot your service instance, you must have the [space developer](/orgs_spaces_users.html#space-developer) and permissions in the [space](/orgs_spaces_users.html#spaces) that hosts your service instance.
 
 Rebooting your service instance will cause a brief service outage. You can minimise the length of this outage by reducing activity in your MySQL database during the reboot.
 

--- a/source/documentation/deploying_services/mysql.md
+++ b/source/documentation/deploying_services/mysql.md
@@ -232,6 +232,35 @@ To upgrade, you must set up a new service and migrate your app data.
 
 You cannot currently downgrade your service plan.
 
+### Reboot a MySQL service instance
+
+You can [reboot](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_RebootInstance.html) [external link] your MySQL service instance to:
+
+- try to fix a problem with your service instance
+- test how your app behaves during a service instance failure
+
+To reboot your service instance, you must have at least [space developer](https://docs.cloud.service.gov.uk/orgs_spaces_users.html#space-developer) permissions or higher in the [space](orgs_spaces_users.html#spaces) that hosts your service instance.
+
+Rebooting your service instance will cause a brief service outage. You can minimise the length of this outage by reducing activity in your MySQL database during the reboot.
+
+Run the following command to reboot your service instance:
+
+```
+cf update-service SERVICE_NAME -c '{"reboot": true}'
+```
+
+where `SERVICE_NAME` is a unique descriptive name for this service instance.
+
+If you have a [highly available service instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html) [external link], you can force a [failover](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html#Concepts.MultiAZ.Failover) when you reboot the service instance. You can use this to test how your app behaves when a failover happens.
+
+Run the following command to reboot your highly available service and force a failover:
+
+```
+cf update-service SERVICE_NAME -c '{"reboot": true, "force_failover": true}'
+```
+
+When you force a failover, your MySQL database IP address will change. The database's hostname will not change. You must close all your database's connections to the previous IP address after forcing a failover.
+
 ### Unbind a MySQL service from your app
 
 You must unbind the MySQL service before you can delete it. To unbind the MySQL service, run the following code in the command line:

--- a/source/documentation/deploying_services/mysql.md
+++ b/source/documentation/deploying_services/mysql.md
@@ -234,16 +234,19 @@ You cannot currently downgrade your service plan.
 
 ### Reboot a MySQL service instance
 
-You can [reboot](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_RebootInstance.html) [external link] your MySQL service instance to:
+You can [reboot your MySQL service instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_RebootInstance.html) [external link] to:
 
 - try to fix a problem with your service instance
 - test how your app behaves during a service instance failure
 
 To reboot your service instance, you must have the [space developer](/orgs_spaces_users.html#space-developer) role and permissions in the [space](/orgs_spaces_users.html#spaces) that hosts your service instance.
 
-Rebooting your service instance will cause a brief service outage. You can minimise the length of this outage by reducing activity in your MySQL database during the reboot.
+Rebooting your service instance will cause a temporary database outage. The length of this outage depends on your service instance’s complexity and configuration.
 
-Run the following command to reboot your service instance:
+
+You should tell your users and your team when a reboot is scheduled.
+
+Run the following in the command line to reboot your service instance:
 
 ```
 cf update-service SERVICE_NAME -c '{"reboot": true}'
@@ -251,9 +254,12 @@ cf update-service SERVICE_NAME -c '{"reboot": true}'
 
 where `SERVICE_NAME` is a unique descriptive name for this service instance.
 
-If you have a [highly available service instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html) [external link], you can force a [failover](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html#Concepts.MultiAZ.Failover) [external link] when you reboot the service instance. You can use this to test how your app behaves when a failover happens.
 
-Run the following command to reboot your highly available service and force a failover:
+#### Force a failover
+
+If you have a [highly available service instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html) [external link], you can force a [failover](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html#Concepts.MultiAZ.Failover) [external link] when you reboot that service instance. You can use this to test how your app behaves when a failover happens.
+
+Run the following to reboot your highly available service and force a failover:
 
 ```
 cf update-service SERVICE_NAME -c '{"reboot": true, "force_failover": true}'

--- a/source/documentation/deploying_services/mysql.md
+++ b/source/documentation/deploying_services/mysql.md
@@ -239,7 +239,7 @@ You can [reboot](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Reb
 - try to fix a problem with your service instance
 - test how your app behaves during a service instance failure
 
-To reboot your service instance, you must have at least [space developer](https://docs.cloud.service.gov.uk/orgs_spaces_users.html#space-developer) permissions or higher in the [space](orgs_spaces_users.html#spaces) that hosts your service instance.
+To reboot your service instance, you must have [space developer](/orgs_spaces_users.html#space-developer) permissions in the [space](/orgs_spaces_users.html#spaces) that hosts your service instance.
 
 Rebooting your service instance will cause a brief service outage. You can minimise the length of this outage by reducing activity in your MySQL database during the reboot.
 
@@ -251,7 +251,7 @@ cf update-service SERVICE_NAME -c '{"reboot": true}'
 
 where `SERVICE_NAME` is a unique descriptive name for this service instance.
 
-If you have a [highly available service instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html) [external link], you can force a [failover](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html#Concepts.MultiAZ.Failover) when you reboot the service instance. You can use this to test how your app behaves when a failover happens.
+If you have a [highly available service instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html) [external link], you can force a [failover](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html#Concepts.MultiAZ.Failover) [external link] when you reboot the service instance. You can use this to test how your app behaves when a failover happens.
 
 Run the following command to reboot your highly available service and force a failover:
 
@@ -259,7 +259,7 @@ Run the following command to reboot your highly available service and force a fa
 cf update-service SERVICE_NAME -c '{"reboot": true, "force_failover": true}'
 ```
 
-When you force a failover, your MySQL database IP address will change. The database's hostname will not change. You must close all your database's connections to the previous IP address after forcing a failover.
+When you force a failover, your MySQL database IP address will change. The database's hostname will not change. You must configure your app to close all database connections to the previous IP address after forcing a failover.
 
 ### Unbind a MySQL service from your app
 

--- a/source/documentation/deploying_services/mysql.md
+++ b/source/documentation/deploying_services/mysql.md
@@ -239,7 +239,7 @@ You can [reboot](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Reb
 - try to fix a problem with your service instance
 - test how your app behaves during a service instance failure
 
-To reboot your service instance, you must have the [space developer](/orgs_spaces_users.html#space-developer) and permissions in the [space](/orgs_spaces_users.html#spaces) that hosts your service instance.
+To reboot your service instance, you must have the [space developer](/orgs_spaces_users.html#space-developer) role and permissions in the [space](/orgs_spaces_users.html#spaces) that hosts your service instance.
 
 Rebooting your service instance will cause a brief service outage. You can minimise the length of this outage by reducing activity in your MySQL database during the reboot.
 

--- a/source/documentation/deploying_services/postgresql.md
+++ b/source/documentation/deploying_services/postgresql.md
@@ -240,7 +240,7 @@ You can [reboot](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Reb
 - try to fix a problem with your service instance
 - test how your app behaves during a service instance failure
 
-To reboot your service instance, you must have [space developer](/orgs_spaces_users.html#space-developer) permissions in the [space](/orgs_spaces_users.html#spaces) that hosts your service instance.
+To reboot your service instance, you must have the [space developer](/orgs_spaces_users.html#space-developer) role and permissions in the [space](/orgs_spaces_users.html#spaces) that hosts your service instance.
 
 Rebooting your service instance will cause a brief service outage. You can minimise the length of this outage by reducing activity in your PostgreSQL database during the reboot.
 

--- a/source/documentation/deploying_services/postgresql.md
+++ b/source/documentation/deploying_services/postgresql.md
@@ -233,6 +233,35 @@ To upgrade, you must set up a new service and migrate your app data.
 
 You cannot currently downgrade your service plan.
 
+### Reboot a PostgreSQL service instance
+
+You can [reboot](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_RebootInstance.html) [external link] your PostgreSQL service instance to:
+
+- try to fix a problem with your service instance
+- test how your app behaves during a service instance failure
+
+To reboot your service instance, you must have at least [space developer](https://docs.cloud.service.gov.uk/orgs_spaces_users.html#space-developer) permissions or higher in the [space](orgs_spaces_users.html#spaces) that hosts your service instance.
+
+Rebooting your service instance will cause a brief service outage. You can minimise the length of this outage by reducing activity in your PostgreSQL database during the reboot.
+
+Run the following command to reboot your service instance:
+
+```
+cf update-service SERVICE_NAME -c '{"reboot": true}'
+```
+
+where `SERVICE_NAME` is a unique descriptive name for this service instance.
+
+If you have a [highly available service instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html) [external link], you can force a [failover](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html#Concepts.MultiAZ.Failover) when you reboot the service instance. You can use this to test how your app behaves when a failover happens.
+
+Run the following command to reboot your highly available service and force a failover:
+
+```
+cf update-service SERVICE_NAME -c '{"reboot": true, "force_failover": true}'
+```
+
+When you force a failover, your PostgreSQL database IP address will change. The database's hostname will not change. You must close all your database's connections to the previous IP address after forcing a failover.
+
 ### Unbind a PostgreSQL service from your app
 
 You must unbind the PostgreSQL service before you can delete it. To unbind the PostgreSQL service, run the following code in the command line:

--- a/source/documentation/deploying_services/postgresql.md
+++ b/source/documentation/deploying_services/postgresql.md
@@ -235,16 +235,19 @@ You cannot currently downgrade your service plan.
 
 ### Reboot a PostgreSQL service instance
 
-You can [reboot](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_RebootInstance.html) [external link] your PostgreSQL service instance to:
+You can [reboot your PostgreSQL service instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_RebootInstance.html) [external link] to:
 
 - try to fix a problem with your service instance
 - test how your app behaves during a service instance failure
 
 To reboot your service instance, you must have the [space developer](/orgs_spaces_users.html#space-developer) role and permissions in the [space](/orgs_spaces_users.html#spaces) that hosts your service instance.
 
-Rebooting your service instance will cause a brief service outage. You can minimise the length of this outage by reducing activity in your PostgreSQL database during the reboot.
+Rebooting your service instance will cause a temporary database outage. The length of this outage depends on your service instance’s complexity and configuration.
 
-Run the following command to reboot your service instance:
+
+You should tell your users and your team when a reboot is scheduled.
+
+Run the following code in the command line to reboot your service instance:
 
 ```
 cf update-service SERVICE_NAME -c '{"reboot": true}'
@@ -252,9 +255,11 @@ cf update-service SERVICE_NAME -c '{"reboot": true}'
 
 where `SERVICE_NAME` is a unique descriptive name for this service instance.
 
-If you have a [highly available service instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html) [external link], you can force a [failover](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html#Concepts.MultiAZ.Failover) [external link] when you reboot the service instance. You can use this to test how your app behaves when a failover happens.
+#### Force a failover
 
-Run the following command to reboot your highly available service and force a failover:
+If you have a [highly available service instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html) [external link], you can force a [failover](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html#Concepts.MultiAZ.Failover) [external link] when you reboot that service instance. You can use this to test how your app behaves when a failover happens.
+
+Run the following code to reboot your highly available service and force a failover:
 
 ```
 cf update-service SERVICE_NAME -c '{"reboot": true, "force_failover": true}'

--- a/source/documentation/deploying_services/postgresql.md
+++ b/source/documentation/deploying_services/postgresql.md
@@ -240,7 +240,7 @@ You can [reboot](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Reb
 - try to fix a problem with your service instance
 - test how your app behaves during a service instance failure
 
-To reboot your service instance, you must have at least [space developer](https://docs.cloud.service.gov.uk/orgs_spaces_users.html#space-developer) permissions or higher in the [space](orgs_spaces_users.html#spaces) that hosts your service instance.
+To reboot your service instance, you must have [space developer](/orgs_spaces_users.html#space-developer) permissions in the [space](/orgs_spaces_users.html#spaces) that hosts your service instance.
 
 Rebooting your service instance will cause a brief service outage. You can minimise the length of this outage by reducing activity in your PostgreSQL database during the reboot.
 
@@ -252,7 +252,7 @@ cf update-service SERVICE_NAME -c '{"reboot": true}'
 
 where `SERVICE_NAME` is a unique descriptive name for this service instance.
 
-If you have a [highly available service instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html) [external link], you can force a [failover](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html#Concepts.MultiAZ.Failover) when you reboot the service instance. You can use this to test how your app behaves when a failover happens.
+If you have a [highly available service instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html) [external link], you can force a [failover](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html#Concepts.MultiAZ.Failover) [external link] when you reboot the service instance. You can use this to test how your app behaves when a failover happens.
 
 Run the following command to reboot your highly available service and force a failover:
 
@@ -260,7 +260,7 @@ Run the following command to reboot your highly available service and force a fa
 cf update-service SERVICE_NAME -c '{"reboot": true, "force_failover": true}'
 ```
 
-When you force a failover, your PostgreSQL database IP address will change. The database's hostname will not change. You must close all your database's connections to the previous IP address after forcing a failover.
+When you force a failover, your PostgreSQL database IP address will change. The database's hostname will not change. You must configure your app to close all database connections to the previous IP address after forcing a failover.
 
 ### Unbind a PostgreSQL service from your app
 


### PR DESCRIPTION
What
----

Add in content for rebooting a PostgreSQL or MySQL service instance. This is a new feature added at the end of last quarter that must be documented.

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Check it fulfils story: https://www.pivotaltracker.com/story/show/163221757

Who can review
--------------

Initial review: Andras. Subsequent full review: Anyone except Andras or Jon G.
