### PR TITLE
Update docs to use tec docs gems v1.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,6 @@ gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
 gem 'govuk_tech_docs'
-gem 'middleman-search', :git => 'https://github.com/alphagov/middleman-search.git'
+# gem 'middleman-search', git: 'git://github.com/alphagov/middleman-search.git'
+
+gem 'therubyracer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,33 +1,24 @@
-GIT
-  remote: https://github.com/alphagov/middleman-search.git
-  revision: 50d072378c6f92a78ea02fed366ec6453aea8552
-  specs:
-    middleman-search (0.10.0)
-      execjs (~> 2.6)
-      middleman-core (>= 3.2)
-      nokogiri (~> 1.6)
-
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.0.7)
+    activesupport (5.0.7.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     autoprefixer-rails (6.7.7.2)
       execjs
     backports (3.11.4)
     chronic (0.10.2)
-    chunky_png (1.3.10)
+    chunky_png (1.3.11)
     coderay (1.1.2)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    commonmarker (0.17.13)
+    commonmarker (0.18.2)
       ruby-enum (~> 0.5)
     compass (1.0.3)
       chunky_png (~> 1.2)
@@ -41,9 +32,9 @@ GEM
       sass (>= 3.3.0, < 3.5)
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.4)
     contracts (0.13.0)
-    dotenv (2.5.0)
+    dotenv (2.6.0)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -51,16 +42,16 @@ GEM
     eventmachine (1.2.7)
     execjs (2.7.0)
     fast_blank (1.0.0)
-    fastimage (2.1.4)
+    fastimage (2.1.5)
     ffi (1.9.25)
-    govuk_tech_docs (1.6.1)
+    govuk_tech_docs (1.8.0)
       activesupport
       chronic (~> 0.10.2)
       middleman (~> 4.0)
       middleman-autoprefixer (~> 2.7.0)
       middleman-compass (>= 4.0.0)
       middleman-livereload
-      middleman-search
+      middleman-search-gds
       middleman-sprockets (~> 4.0.0)
       middleman-syntax (~> 3.0.0)
       nokogiri
@@ -74,34 +65,34 @@ GEM
       concurrent-ruby (~> 1.0)
     hashie (3.6.0)
     http_parser.rb (0.6.0)
-    i18n (0.7.0)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
     kramdown (1.17.0)
+    libv8 (3.16.14.19)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     memoist (0.16.0)
-    method_source (0.9.0)
-    middleman (4.2.1)
+    method_source (0.9.2)
+    middleman (4.3.2)
       coffee-script (~> 2.2)
-      compass-import-once (= 1.0.5)
       haml (>= 4.0.5)
       kramdown (~> 1.2)
-      middleman-cli (= 4.2.1)
-      middleman-core (= 4.2.1)
-      sass (>= 3.4.0, < 4.0)
+      middleman-cli (= 4.3.2)
+      middleman-core (= 4.3.2)
     middleman-autoprefixer (2.7.1)
       autoprefixer-rails (>= 6.5.2, < 7.0.0)
       middleman-core (>= 3.3.3)
-    middleman-cli (4.2.1)
+    middleman-cli (4.3.2)
       thor (>= 0.17.0, < 2.0)
     middleman-compass (4.0.1)
       compass (>= 1.0.0, < 2.0.0)
       middleman-core (>= 4.0.0)
-    middleman-core (4.2.1)
+    middleman-core (4.3.2)
       activesupport (>= 4.2, < 5.1)
       addressable (~> 2.3)
       backports (~> 3.6)
-      bundler (~> 1.1)
+      bundler
       contracts (~> 0.13.0)
       dotenv
       erubis
@@ -110,31 +101,35 @@ GEM
       fastimage (~> 2.0)
       hamster (~> 3.0)
       hashie (~> 3.4)
-      i18n (~> 0.7.0)
+      i18n (~> 0.9.0)
       listen (~> 3.0.0)
       memoist (~> 0.14)
       padrino-helpers (~> 0.13.0)
       parallel
       rack (>= 1.4.5, < 3)
-      sass (>= 3.4)
+      sassc (~> 2.0)
       servolux
-      tilt (~> 2.0)
+      tilt (~> 2.0.9)
       uglifier (~> 3.0)
     middleman-livereload (3.4.6)
       em-websocket (~> 0.5.1)
       middleman-core (>= 3.3)
       rack-livereload (~> 0.3.15)
+    middleman-search-gds (0.11.0a)
+      execjs (~> 2.6)
+      middleman-core (>= 3.2)
+      nokogiri (~> 1.6)
     middleman-sprockets (4.0.0)
       middleman-core (~> 4.0)
       sprockets (>= 3.0)
     middleman-syntax (3.0.0)
       middleman-core (>= 3.2)
       rouge (~> 2.0)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     minitest (5.11.3)
     multi_json (1.13.1)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.10.1)
+      mini_portile2 (~> 2.4.0)
     openapi3_parser (0.5.2)
       commonmarker (~> 0.17)
     padrino-helpers (0.13.3.4)
@@ -143,30 +138,38 @@ GEM
       tilt (>= 1.4.1, < 3)
     padrino-support (0.13.3.4)
       activesupport (>= 3.1)
-    parallel (1.12.1)
-    pry (0.11.3)
+    parallel (1.13.0)
+    pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.0.3)
     rack (2.0.6)
     rack-livereload (0.3.17)
       rack
+    rake (12.3.2)
     rb-fsevent (0.10.3)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
     redcarpet (3.3.4)
+    ref (2.0.0)
     rouge (2.2.1)
     ruby-enum (0.7.2)
       i18n
     sass (3.4.25)
+    sassc (2.0.0)
+      ffi (~> 1.9.6)
+      rake
     servolux (0.13.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     temple (0.8.0)
-    thor (0.20.0)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
+      ref
+    thor (0.20.3)
     thread_safe (0.3.6)
-    tilt (2.0.8)
+    tilt (2.0.9)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
@@ -177,9 +180,9 @@ PLATFORMS
 
 DEPENDENCIES
   govuk_tech_docs
-  middleman-search!
+  therubyracer
   tzinfo-data
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   1.16.6
+   1.17.1


### PR DESCRIPTION
What
----

Update tech docs to use the latest version of tech docs gem (v1.8.0).

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).

Who can review
--------------

Anyone excluding Jon Glassman.
