### PR TITLE
Update govuk_tech_docs gem to 1.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
 # Windows does not come with time zone data
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
-gem 'govuk_tech_docs'
+gem 'govuk_tech_docs', '1.8.0'
 gem 'middleman-search', :git => 'https://github.com/alphagov/middleman-search.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,13 +21,13 @@ GEM
       execjs
     backports (3.11.4)
     chronic (0.10.2)
-    chunky_png (1.3.10)
+    chunky_png (1.3.11)
     coderay (1.1.2)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    commonmarker (0.17.13)
+    commonmarker (0.18.2)
       ruby-enum (~> 0.5)
     compass (1.0.3)
       chunky_png (~> 1.2)
@@ -53,14 +53,14 @@ GEM
     fast_blank (1.0.0)
     fastimage (2.1.4)
     ffi (1.9.25)
-    govuk_tech_docs (1.6.1)
+    govuk_tech_docs (1.8.0)
       activesupport
       chronic (~> 0.10.2)
       middleman (~> 4.0)
       middleman-autoprefixer (~> 2.7.0)
       middleman-compass (>= 4.0.0)
       middleman-livereload
-      middleman-search
+      middleman-search-gds
       middleman-sprockets (~> 4.0.0)
       middleman-syntax (~> 3.0.0)
       nokogiri
@@ -80,7 +80,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     memoist (0.16.0)
-    method_source (0.9.0)
+    method_source (0.9.2)
     middleman (4.2.1)
       coffee-script (~> 2.2)
       compass-import-once (= 1.0.5)
@@ -124,6 +124,10 @@ GEM
       em-websocket (~> 0.5.1)
       middleman-core (>= 3.3)
       rack-livereload (~> 0.3.15)
+    middleman-search-gds (0.11.0a)
+      execjs (~> 2.6)
+      middleman-core (>= 3.2)
+      nokogiri (~> 1.6)
     middleman-sprockets (4.0.0)
       middleman-core (~> 4.0)
       sprockets (>= 3.0)
@@ -144,7 +148,7 @@ GEM
     padrino-support (0.13.3.4)
       activesupport (>= 3.1)
     parallel (1.12.1)
-    pry (0.11.3)
+    pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.0.3)
@@ -164,7 +168,7 @@ GEM
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     temple (0.8.0)
-    thor (0.20.0)
+    thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.8)
     tzinfo (1.2.5)
@@ -176,10 +180,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  govuk_tech_docs
+  govuk_tech_docs (= 1.8.0)
   middleman-search!
   tzinfo-data
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   1.16.6
+   1.17.2


### PR DESCRIPTION
What
----

Updating the govuk_tech_docs gem

How to review
-------------

- `docker build -t test .` and run`docker run -p 8080:4567 -v $(pwd)/paas-tech-docs:/tmp -it test /bin/sh`
- `cd /tmp` and run `make test`
- Run `bundle exec middleman server`
- Go to `localhost:8080`, preview the content locally and check that it renders as expected
- Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this)

Who can review
--------------

Not @mogds 