### PR TITLE
Update how to make the shell match the buildpack environment

### DIFF
--- a/source/documentation/troubleshooting/ssh.md
+++ b/source/documentation/troubleshooting/ssh.md
@@ -19,7 +19,7 @@ SSH is enabled by default. In most cases, you will find that you can SSH directl
 2. For some tasks to work, you need to set up the interactive SSH session to match the buildpack environment. To do this, run:
 
     ```
-    exec /tmp/lifecycle/launcher /home/vcap/app "bash -l" ""
+    /tmp/lifecycle/shell
     ```
 
     You need to run this every time you start an SSH session.


### PR DESCRIPTION
buildpacks now provide a single command to make the ssh session match the environment of the running app.
as documented in https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-env
which was changed in https://github.com/cloudfoundry/docs-dev-guide/commit/ec036e7115ec24f2b9f58ff8abb67bee08a9a43b

What
----

Describe what you have changed and why.

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. …

Who can review
--------------

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.
