### PR TITLE
[SUPPORT] Explain `apps.internal` DNS behaviour

### DIFF
--- a/source/documentation/deploying_apps/index.erb
+++ b/source/documentation/deploying_apps/index.erb
@@ -144,7 +144,7 @@ where:
 - `ENVIRONMENT_VARIABLE_NAME` is the [environment variable](#environment-variables) your public app reads (for example `PRIVATE_APP_URL`)
 - `PRIVATE_APPNAME` is the name of your private app
 
-<%= warning_text('When an app is accessed via the `*.apps.internal` DNS name (ie. by another app), the DNS resolution is case-sensitive. An app with the FQDN `test.apps.internal` can only be accessed as `test.apps.internal`: `TesT.apps.InternaL` will not be resolveable.') %>
+<%= warning_text('When an app accesses a private app using the `*.apps.internal` DNS, this DNS must exactly match the route defined in the private app manifest. This includes capitalisation. <br><br> For example, a public app tries to access a private app that has the route `test.apps.internal`. If the public app uses `TesT.apps.InternaL`, this will cause an error.') %>
 
 ### Create a network policy
 

--- a/source/documentation/deploying_apps/index.erb
+++ b/source/documentation/deploying_apps/index.erb
@@ -144,6 +144,8 @@ where:
 - `ENVIRONMENT_VARIABLE_NAME` is the [environment variable](#environment-variables) your public app reads (for example `PRIVATE_APP_URL`)
 - `PRIVATE_APPNAME` is the name of your private app
 
+<%= warning_text('When an app is accessed via the `*.apps.internal` DNS name (ie. by another app), the DNS resolution is case-sensitive. An app with the FQDN `test.apps.internal` can only be accessed as `test.apps.internal`: `TesT.apps.InternaL` will not be resolveable.') %>
+
 ### Create a network policy
 
 By default, Cloud Foundry apps do not accept internal connections from other apps.


### PR DESCRIPTION
What
----

Add a warning to explain that `apps.internal` DNS resolution will be case-sensitive: apps will not be routable if called with the wrong-cased dns name.

How to review
-------------

Describe the steps required to test the changes.

1. Check that the amendment makes sense, and conveys the correct meaning
1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.

Who can review
--------------

Not me. @jonathanglassman, could you please take a look?
