### PR TITLE
[#163694261] Workaround tech-docs-gem bug by using HTML headings

### DIFF
--- a/source/documentation/deploying_services/elasticsearch.md
+++ b/source/documentation/deploying_services/elasticsearch.md
@@ -6,7 +6,7 @@ This implementation of Elasticsearch is a request-only private beta trial versio
 
 Before using Elasticsearch as your primary data store, you should assess if an [ACID-compliant](https://www.techopedia.com/definition/23949/atomicity-consistency-isolation-durability-acid) [external link] backing service such as [PostgreSQL](/deploying_services/postgresql/#postgresql) or [MySQL](/deploying_services/mysql/#mysql) would better meet your needs.
 
-## Set up the service
+<h2 id="set-up-the-service">Set up the service</h2>
 
 ### Set up an Elasticsearch service
 
@@ -128,7 +128,7 @@ Alternatively, you can manually bind your service instance to your app.
 
 Refer to the Cloud Foundry documentation on [deploying with app manifests](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#services-block) [external link] for more information.
 
-## Amend the service
+<h2 id="amend-the-service">Amend the service</h2>
 
 ### Upgrade Elasticsearch service plan
 
@@ -146,7 +146,7 @@ cf update-service my-elasticsearch-service -p small-ha-6.x
 
 The plan upgrade will start immediately and finish within an hour. You can check the status of the upgrade by running `cf services`.
 
-## Remove the service
+<h2 id="remove-the-service">Remove the service</h2>
 
 ### Unbind an Elasticsearch service from your app
 
@@ -180,7 +180,7 @@ cf delete-service my-es-service
 
 Enter `yes` when asked for confirmation.
 
-## Maintaining the service
+<h2 id="maintaining-the-service">Maintaining the service</h2>
 
 ### Data classification
 

--- a/source/documentation/deploying_services/mysql.md
+++ b/source/documentation/deploying_services/mysql.md
@@ -2,7 +2,7 @@
 
 MySQL is an open source relational database management system that uses Structured Query Language (SQL) and is backed by Oracle.
 
-## Set up the service
+<h2 id="set-up-the-service">Set up the service</h2>
 
 ### Set up a MySQL service
 
@@ -142,7 +142,7 @@ where `SERVICE_NAME` is a unique descriptive name for this service instance.
 
 Run `cf conduit --help` for more options, and refer to the [Conduit readme file](https://github.com/alphagov/paas-cf-conduit/blob/master/README.md) [external link] for more information on how to use the plugin.
 
-## Amend the service
+<h2 id="amend-the-service">Amend the service</h2>
 
 ### Import and export bulk data to and from a MySQL database
 
@@ -271,7 +271,7 @@ cf update-service SERVICE_NAME -c '{"reboot": true, "force_failover": true}'
 
 When you force a failover, your MySQL database IP address will change. The database's hostname will not change. You must configure your app to close all database connections to the previous IP address after forcing a failover.
 
-## Remove the service
+<h2 id="remove-the-service">Remove the service</h2>
 
 ### Unbind a MySQL service from your app
 
@@ -301,7 +301,7 @@ where `SERVICE_NAME` is a unique descriptive name for this service instance.
 
 Type `yes` when asked for confirmation.
 
-## Maintaining the service
+<h2 id="maintaining-the-service">Maintaining the service</h2>
 
 ### Data classification
 

--- a/source/documentation/deploying_services/postgresql.md
+++ b/source/documentation/deploying_services/postgresql.md
@@ -2,7 +2,7 @@
 
 PostgreSQL is an object-relational database management system. It is open source and designed to be extensible.
 
-## Set up the service
+<h2 id="set-up-the-service">Set up the service</h2>
 
 ### Set up a PostgreSQL service
 
@@ -143,7 +143,7 @@ where `SERVICE_NAME` is a unique descriptive name for this service instance.
 
 Run `cf conduit --help` for more options, and refer to the [Conduit readme file](https://github.com/alphagov/paas-cf-conduit/blob/master/README.md) [external link] for more information on how to use the plugin.
 
-## Amend the service
+<h2 id="amend-the-service">Amend the service</h2>
 
 ### Import and export bulk data to and from a PostgreSQL database
 
@@ -383,7 +383,7 @@ where:
 Refer to the documentation on [restoring a PostgreSQL service snapshot](#restoring-a-postgresql-service-snapshot) for more information.
 
 
-## Remove the service
+<h2 id="remove-the-service">Remove the service</h2>
 
 ### Unbind a PostgreSQL service from your app
 
@@ -413,7 +413,7 @@ where `SERVICE_NAME` is a unique descriptive name for this service instance.
 
 Type `yes` when asked for confirmation.
 
-## Maintaining the service
+<h2 id="maintaining-the-service">Maintaining the service</h2>
 
 ### Data classification
 

--- a/source/documentation/deploying_services/redis.md
+++ b/source/documentation/deploying_services/redis.md
@@ -2,7 +2,7 @@
 
 Redis is an open source in-memory data store that can be used as a database cache or message broker.
 
-## Set up the service
+<h2 id="set-up-the-service">Set up the service</h2>
 
 ### Set up a Redis service
 
@@ -159,7 +159,7 @@ PONG
 
 Run `cf conduit --help` for more options, and refer to the [Conduit readme file](https://github.com/alphagov/paas-cf-conduit/blob/master/README.md) [external link] for more information on how to use the plugin.
 
-## Remove the service
+<h2 id="remove-the-service">Remove the service</h2>
 
 ### Unbind a Redis service from your app
 
@@ -189,7 +189,7 @@ where `SERVICE_NAME` is a unique descriptive name for this service instance.
 
 Type `yes` when asked for confirmation.
 
-## Maintaining the service
+<h2 id="maintaining-the-service">Maintaining the service</h2>
 
 ### Data classification
 


### PR DESCRIPTION
What
----
There is a bug [1] in tech-docs-gem that causes identical headings on different
pages to be generated with incorrect identifiers. The behaviour is correct for
headings on the same page, but not for different pages as here. Jon Hallam, Jon
Glassman, and I agreed that a workaround using HTML headings was suitable here.

[1] https://github.com/alphagov/tech-docs-template/issues/180

How to review
-------------

Describe the steps required to test the changes.

1. Code review
2. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
3. Check that all the table of contents headings under "Deploy a backing or routing service" work, and go to the right part of the page

Who can review
--------------
@jonathanglassman 