### PR TITLE
[#165350427] Penetration testing no longer requires AWS authorisation

### DIFF
--- a/source/documentation/guidance/pentest.md
+++ b/source/documentation/guidance/pentest.md
@@ -1,17 +1,14 @@
 ## Penetration testing
 
-You must penetration test your app to make sure it’s secure. Note that you can only penetration test your app; you cannot penetration test the platform.
+[Is is your responsibility](#responsibility-model) to penetration test your app to make sure it’s secure. Note that you can only penetration test your app; you cannot penetration test the platform. 
 
-Because GOV.UK PaaS runs on Amazon Web Services (AWS), you need permission from AWS to penetration test your app. The PaaS team will request permission for you because the process requires root credentials for the AWS portal.
-
-Send the below information to [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) and the PaaS team will share it with AWS.
+You must send the below information to [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) so that we are aware of your penetration test and can approve it.
 
 |Supplied by penetration tester|
 |:---|
 |Tester phone number|
 |Emergency email and phone number contact details|
 |Will the requests originate from the tester’s office?|
-|Has the tester has signed a non-disclosure agreement (NDA) with AWS?|
 |The origin IPs|
 |Peak bandwidth that the tests will consume in gigabits per second|
 |Peak number of requests per second the tests will perform|
@@ -26,12 +23,7 @@ Send the below information to [gov-uk-paas-support@digital.cabinet-office.gov.uk
 
 You should supply as much information as possible to minimise delays in this process.
 
-AWS responds to permission requests within two business days. The PaaS team will forward the AWS response to you within two further business days of receiving it.
-
-If your request is approved, you will receive an authorisation number. Your penetration test is only authorised for the dates and times you have specified.
-
-If your request is not approved, the PaaS team will work with you and AWS to solve any issues. 
-
+If your request is approved, your penetration test is only authorised for the dates and times you have specified.
 
 
 ### Further information


### PR DESCRIPTION
What
----
Penetration testing no longer requires AWS authorisation

However, we still want to hear from tenants when they carry out pen tests. This
commit changes our penetration testing guidance to no longer mentioned the need
for AWS authorisation.


How to review
-------------
1. Review the copy
1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.

Who can review
--------------
@tnwhitwell for technical accuracy, @jonathanglassman for the quality of the copy.
