### PR TITLE
Update the s3 docs to be accurate about live

### DIFF
--- a/source/documentation/deploying_services/s3.md
+++ b/source/documentation/deploying_services/s3.md
@@ -2,7 +2,8 @@
 
 Amazon S3 provides data object storage through a web service interface.
 
-The Amazon S3 backing service is in private beta and may not be suitable for all services. To request access and discuss your services needs, contact the GOV.UK PaaS team at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
+To provide any feedback on this feature, contact the GOV.UK PaaS team at
+[gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
 
 <h2 id="set-up-the-service">Set up the service</h2>
 


### PR DESCRIPTION
What
----

```
luke.malcher [07:30 Uhr]
>The Amazon S3 backing service is in private beta and may not be suitable for all services. To request access and discuss your services needs, contact the GOV.UK PaaS team at gov-uk-paas-support@digital.cabinet-office.gov.uk.

this is no longer accurate - do we need a story to update it? seems like a v small task
we could probably just replace this with "To provide any feedback on this feature, contact the GOV.UK PaaS team at gov-uk-paas-support@digital.cabinet-office.gov.uk."
Would be good to update it before we start shouting about he feature, so that people feel comfortable using it
```

How to review
-------------

Code review

Who can review
--------------

Not @tlwr
