### PR TITLE
[#165850892] Don't output Linkchecker warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ifdef VERBOSE
 VERBOSE_FLAG:=--verbose
 endif
 
-LINKCHECKER := linkchecker --ignore-url=^mailto: -f ./.linkchecker.rc $(VERBOSE_FLAG)
+LINKCHECKER := linkchecker --no-warnings --ignore-url=^mailto: -f ./.linkchecker.rc $(VERBOSE_FLAG)
 SERVER_PORT?=4567
 
 .PHONY: help


### PR DESCRIPTION
What
----

See https://wummel.github.io/linkchecker/man1/linkchecker.1.html

```
--no-warnings
    Don't log warnings. Default is to log warnings.
```

These warnings could arguably be useful, but in practice it looks like
they fire in an unreliable way, so we're just ignoring them.

Having flakey tests is hurting us more than this tool is helping us
avoid broken links.

How to review
-------------

* Code review is probably enough

Who can review
--------------

Not @richardtowers