### PR TITLE
Cache Control Header in cdn-route service

### DIFF
--- a/source/documentation/deploying_services/use_a_custom_domain.erb
+++ b/source/documentation/deploying_services/use_a_custom_domain.erb
@@ -22,6 +22,9 @@ You must configure the cdn-route service to use a subdomain. If you configure th
 
 Once you create a CDN service instance, you cannot update or delete the instance until you have completed the setup process. If you make a mistake that breaks the configuration, email GOV.UK PaaS support at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) to delete the service instance.
 
+<%= warning_text('The cdn-route service automatically caches responses from custom domains. <br><br> When you want to change the response from your custom domain, you must set a Cache-Control response header to specify that the cdn-route service should cache responses for a finite amount of time.') %>
+
+
 ## Set up the service
 
 ### Set up a cdn-route service with one or more custom domains


### PR DESCRIPTION
What
----

Added warning to cdn-route service content stating that you must set a Cache-Control response header if you want to ensure that you can change the response coming from your custom domain.

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Check it fulfils story: https://www.pivotaltracker.com/story/show/165995762

Who can review
--------------

Anyone but Jon Glassman
