### PR TITLE
Update the CI docs now paas-admin manages users

### DIFF
--- a/source/documentation/using_ci/index.md
+++ b/source/documentation/using_ci/index.md
@@ -17,7 +17,7 @@ You should focus on how the tool encrypts and protects any sensitive information
 
 ## Configure your CI tool accounts
 
-You should request one or more dedicated PaaS user accounts for use by your CI tool.
+You should create one or more dedicated PaaS user accounts for use by your CI tool.
 
 Use a different account for each [space](/orgs_spaces_users.html#spaces) you want to deploy your app to using your CI tool.
 


### PR DESCRIPTION
What
----

A tenant asked us to create them some CI users, because this line of our documentation told them to request their creation. But `paas-admin` now allows tenants to do their own user management. As such, this commit stops telling tenants to specially request CI accounts.

How to review
-------------

Code review.

Who can review
--------------

Not @46bit 