### PR TITLE
Reduce number of things to declare about pen tests

### DIFF
--- a/source/documentation/guidance/pentest.md
+++ b/source/documentation/guidance/pentest.md
@@ -13,18 +13,9 @@ You must send the below information to [gov-uk-paas-support@digital.cabinet-offi
 |Peak bandwidth that the tests will consume in gigabits per second|
 |Peak number of requests per second the tests will perform|
 |Start and end dates and times of the test in the format YYYY-MM-DDTHH:MM:SSZ for example 2017-09-26T09:00:00Z|
-|The metrics you will measure to decide if the test succeeds or fails|
 |Is it possible to stop the test immediately if there is an issue?|
 
-|Supplied by tenant|
-|:---|
-|Is the tester a third-party company?|
-|What is the purpose of the test and what is being covered?|
-
-You should supply as much information as possible to minimise delays in this process.
-
 If your request is approved, your penetration test is only authorised for the dates and times you have specified.
-
 
 ### Further information
 


### PR DESCRIPTION
What
----

There used to be a lot of information here that we needed to send to
AWS, but we don't need to do that anymore, so we can afford to ask for
less.

I don't think we care about the things that I've removed.

How to review
-------------

* Code review is enough
* I think there's no need for two-eye review since I'm only removing content

Who can review
--------------

Not Rich, maybe Jon?