### PR TITLE
Add in Cloud Foundry v3 API

### DIFF
--- a/source/documentation/deploying_apps/index.erb
+++ b/source/documentation/deploying_apps/index.erb
@@ -161,7 +161,7 @@ cf add-network-policy PUBLIC_APPNAME --destination-app PRIVATE_APPNAME --protoco
 
 #### Recreate the network policy (optional)
 
-If you are using [version 2.0 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v2) and a [blue-green deployment tool](https://docs.cloudfoundry.org/devguide/deploy-apps/blue-green.html).
+If you are using [version 2.0 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v2) and a [blue-green deployment tool](https://docs.cloudfoundry.org/devguide/deploy-apps/blue-green.html) to reduce downtime, you must recreate the network policy every time you push your apps.
 
 This is because every time you push your apps, the blue-green deployment creates a new version of the public app, so the network policy will no longer work.
 

--- a/source/documentation/deploying_apps/index.erb
+++ b/source/documentation/deploying_apps/index.erb
@@ -161,7 +161,7 @@ cf add-network-policy PUBLIC_APPNAME --destination-app PRIVATE_APPNAME --protoco
 
 #### Recreate the network policy (optional)
 
-If you are using [version 2.0 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v2) and a [blue-green deployment process](https://docs.cloudfoundry.org/devguide/deploy-apps/blue-green.html) to reduce downtime, you must recreate the network policy every time you push your apps.
+If you are using [version 2.0 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v2) and a [blue-green deployment tool](https://docs.cloudfoundry.org/devguide/deploy-apps/blue-green.html).
 
 This is because every time you push your apps, the blue-green deployment creates a new version of the public app, so the network policy will no longer work.
 

--- a/source/documentation/deploying_apps/index.erb
+++ b/source/documentation/deploying_apps/index.erb
@@ -159,6 +159,14 @@ You must create a [network policy](https://cli.cloudfoundry.org/en-US/cf/add-net
 cf add-network-policy PUBLIC_APPNAME --destination-app PRIVATE_APPNAME --protocol tcp --port 8080
 ```
 
+#### Recreate the network policy (optional)
+
+If you are using [version 2.0 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v2) and a [blue-green deployment process](https://docs.cloudfoundry.org/devguide/deploy-apps/blue-green.html) to reduce downtime, you must recreate the network policy every time you push your apps.
+
+This is because every time you push your apps, the blue-green deployment creates a new version of the public app, so the network policy will no longer work.
+
+[Version 3.0 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v3) deploys your app with zero downtime. You do not need to recreate the network policy every time you push your apps.
+
 Contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) if you have any further questions.
 
 ## Data security classification

--- a/source/documentation/deploying_apps/index.erb
+++ b/source/documentation/deploying_apps/index.erb
@@ -159,15 +159,18 @@ You must create a [network policy](https://cli.cloudfoundry.org/en-US/cf/add-net
 cf add-network-policy PUBLIC_APPNAME --destination-app PRIVATE_APPNAME --protocol tcp --port 8080
 ```
 
-#### Recreate the network policy (optional)
+#### Recreate the network policy
 
-If you are using [version 2.0 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v2) and a [blue-green deployment tool](https://docs.cloudfoundry.org/devguide/deploy-apps/blue-green.html) to reduce downtime, you must recreate the network policy every time you push your apps.
+You must recreate the network policy every time you push your app if you’re using both:
 
-This is because every time you push your apps, the blue-green deployment creates a new version of the public app, so the network policy will no longer work.
+- [version 2 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v2)
+- a [blue-green deployment tool](https://docs.cloudfoundry.org/devguide/deploy-apps/blue-green.html) to reduce downtime
 
-[Version 3.0 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v3) deploys your app with zero downtime. You do not need to recreate the network policy every time you push your apps.
+This is because every time you push your app, the blue-green deployment tool creates a new version of the public app. The existing network policy will then no longer work.
 
-Contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) if you have any further questions.
+[Version 3 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v3) deploys your app with zero downtime. You do not need to recreate the network policy every time you push your app.
+
+Contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) if you have any questions.
 
 ## Data security classification
 

--- a/source/documentation/getting_started/get_started.erb
+++ b/source/documentation/getting_started/get_started.erb
@@ -225,7 +225,7 @@ If you are using [v2 of the Cloud Foundry API](https://github.com/cloudfoundry/c
 5.  Apply your created manifest file to your app:
 
     ```
-    Cf v3-apply-manifest -f PATH_TO_MANIFEST
+    cf v3-apply-manifest -f PATH_TO_MANIFEST
     ```
 
 6. Push a zero downtime version of your app:

--- a/source/documentation/getting_started/get_started.erb
+++ b/source/documentation/getting_started/get_started.erb
@@ -86,15 +86,15 @@ If you work at GDS, you can enable single sign-on for your account via the GOV.U
 
 When you have signed in, run `cf` in the command line to see all available commands.
 
-## Deploy a test static HTML page using Cloud Foundry API v2
+## Deploy a test static HTML page
 
 You can practice deploying an app by deploying a test static HTML page.
 
-The following instructions tell you how to deploy a static HTML page using [v2 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v2).
+You can use [version 2](get_started.html#use-cloud-foundry-api-version-2) or [version 3](get_started.html#use-cloud-foundry-api-version-3) of the Cloud Foundry API.
 
-If you are using [v3 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v3), refer to the documentation on [deploying a test static HTML page using Cloud Foundry API v3](get_started.html#deploy-a-test-static-html-page-using-cloud-foundry-api-v3).
+If you're not sure which version of the Cloud Foundry API to use, contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
 
-If you are not sure which version of the Cloud Foundry API to use, contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
+### Use Cloud Foundry API version 2
 
 1. To deploy an app, you must select a [target](deploying_apps.html#set-a-target). This is a combination of an [organisation](/orgs_spaces_users.html#organisations) and a [space](/orgs_spaces_users.html#spaces).
 
@@ -128,7 +128,8 @@ If you are not sure which version of the Cloud Foundry API to use, contact us at
     applications:
     - name: APPNAME
       memory: 64M
-      buildpack: staticfile_buildpack
+      buildpacks:
+      - staticfile_buildpack
     ```
 
     where `APPNAME` is the unique name for your app. You can run `cf apps` to see apps which already exist.
@@ -143,23 +144,17 @@ If you are not sure which version of the Cloud Foundry API to use, contact us at
 
 The static HTML page is now available at your [app domain](/orgs_spaces_users.html#regions).
 
-For a production app, you should read the [production checklist](deploying_apps.html#production-checklist).
+For a production app, you should follow the [production checklist](deploying_apps.html#production-checklist).
 
-## Deploy a test static HTML page using Cloud Foundry API v3
+### Use Cloud Foundry API version 3
 
-You can practice deploying an app by deploying a test static HTML page.
-
-The following instructions tell you how to deploy a static HTML page using [v3 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v3). This version of the API allows you to push an app with no downtime without needing to use a [blue-green deployment tool](https://docs.cloudfoundry.org/devguide/deploy-apps/blue-green.html).
+Version 3 allows you to push an app with no downtime without having to use a [blue-green deployment tool](https://docs.cloudfoundry.org/devguide/deploy-apps/blue-green.html).
 
 <br>
 
-<%= warning_text('Cloud Foundry API v3 is still in beta.') %>
+<%= warning_text('Version 3 of the Cloud Foundry API is still in beta.') %>
 
-Refer to the [Cloud Foundry documentation on the limitations of the v3 API](https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html#limitations) for more information.
-
-If you are using [v2 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v2), refer to the documentation on [deploying a test static HTML page using Cloud Foundry API v2](get_started.html#deploy-a-test-static-html-page-using-cloud-foundry-api-v2).
-
-If you are not sure which version of the Cloud Foundry API to use, contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
+Refer to the [Cloud Foundry documentation on the limitations of API version 3](https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html#limitations) for more information.
 
 1. To deploy an app, you must select a [target](deploying_apps.html#set-a-target). This is a combination of an [organisation](/orgs_spaces_users.html#organisations) and a [space](/orgs_spaces_users.html#spaces).
 
@@ -209,9 +204,9 @@ If you are not sure which version of the Cloud Foundry API to use, contact us at
     cf v3-create-app APPNAME
     ```
 
-    APPNAME is the unique name for your app that you specified in the manifest file.
+    `APPNAME` is the unique name for your app that you specified in the manifest file.
 
-    If you have an existing Cloud Foundry API v2 app and want to upgrade this app to use v3, you do not need to do this step.
+    You only need to run this command if you’re creating a new app that uses version 3 of the API.
 
 5.  Apply your created manifest file to your app:
 
@@ -228,6 +223,6 @@ If you are not sure which version of the Cloud Foundry API to use, contact us at
 
 The static HTML page is now available at your [app domain](/orgs_spaces_users.html#regions).
 
-For a production app, you should read the [production checklist](deploying_apps.html#production-checklist).
+For a production app, you should follow the [production checklist](deploying_apps.html#production-checklist) to deploy that app.
 
-Refer to the [Cloud Foundry documentation on rolling app deployments](https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html) for more information on v3 of the Cloud Foundry API.
+Refer to the [Cloud Foundry documentation on rolling app deployments](https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html) for more information on version 3 of the Cloud Foundry API.

--- a/source/documentation/getting_started/get_started.erb
+++ b/source/documentation/getting_started/get_started.erb
@@ -34,6 +34,8 @@ Refer to the Cloud Foundry documentation on [using the Cloud Foundry CLI with a 
 
 You can sign in to Cloud Foundry using either your [GOV.UK PaaS account information](get_started.html#get-an-account) or the single sign-on function.
 
+Single sign-on is only available to users within the Government Digital Service (GDS)
+
 ### Use your GOV.UK PaaS account
 
 The default method to sign in to Cloud Foundry is to use your [GOV.UK PaaS account](get_started.html#get-an-account) information.
@@ -56,50 +58,33 @@ The default method to sign in to Cloud Foundry is to use your [GOV.UK PaaS accou
 
 When you have signed in, run `cf` in the command line to see all available commands.
 
-### Use single sign-on 
+### Use the single sign-on function
 
-You can sign in to Cloud Foundry using the single sign-on function. 
+Single sign-on is only available to users within the Government Digital Service (GDS).
 
-Using single sign-on makes managing your security, joining and leaving processes simpler by reducing the number of passwords or accounts you have to manage.
+If you work at GDS, you can enable single sign-on for your account via the GOV.UK PaaS admin tool.
 
-You must have either a [Google](https://myaccount.google.com/intro) or [Microsoft](https://account.microsoft.com/account) email address to use single sign-on. The email address must be the same as the one you use to sign into your GOV.UK PaaS account.
-
-#### Enable single sign-on
-
-1. Sign into the GOV.UK PaaS admin tool for [London](https://admin.london.cloud.service.gov.uk/) or [Ireland](https://admin.cloud.service.gov.uk/). 
-
-1. Select __Set up Google/Microsoft single sign-on__ and then select __Activate Google/Microsoft single sign-on__.
-
-1. Get a URL to generate a temporary authentication code. If your org is hosted in [London](orgs_spaces_users.html#regions), run the following in the command line:
+1. Once you have access to SSO and if your org is hosted in London, run the following in the command line:
 
     ```
     cf login -a api.london.cloud.service.gov.uk --sso
     ```
 
-    If your org is hosted in [Ireland](orgs_spaces_users.html#regions), run:
+    If your org is hosted in Ireland, run:
 
     ```
     cf login -a api.cloud.service.gov.uk --sso
     ```
 
-1. Go to the URL and select __Continue__ under either __Google__ or __Microsoft__.
+    This will give you a URL where you can generate a temporary authentication code.
 
-1. On the __Sign in__ page, enter or select your email address.
+1. Go to the URL and select the __Sign in using the GOV.UK PaaS internal account login__ button.
 
-1. Enter your password and, if applicable, the 2-step verification code to generate a temporary authentication code.
+1. On the __Sign in with Google__ page, select your `@digital.cabinet-office.gov.uk` email address.
 
-1. Copy the generated temporary authentication code into the command line.
+1. Copy the temporary authentication code into the command line.
 
-When you have signed in, you will see code similar to the following:
-
-```
-API endpoint:   https://api.london.cloud.service.gov.uk (API version: 2.136.0)
-User:           john.smith@digital.cabinet-office.gov.uk
-Org:            hmrc-prod
-Space:          sandbox
-
-```
-
+When you have signed in, run `cf` in the command line to see all available commands.
 
 ## Deploy a test static HTML page using Cloud Foundry API v2
 
@@ -108,6 +93,8 @@ You can practice deploying an app by deploying a test static HTML page.
 The following instructions tell you how to deploy a static HTML page using [v2 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v2).
 
 If you are using [v3 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v3), refer to the documentation on [deploying a test static HTML page using Cloud Foundry API v3](get_started.html#deploy-a-test-static-html-page-using-cloud-foundry-api-v3).
+
+If you are not sure which version of the Cloud Foundry API to use, contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
 
 1. To deploy an app, you must select a [target](deploying_apps.html#set-a-target). This is a combination of an [organisation](/orgs_spaces_users.html#organisations) and a [space](/orgs_spaces_users.html#spaces).
 
@@ -162,13 +149,17 @@ For a production app, you should read the [production checklist](deploying_apps.
 
 You can practice deploying an app by deploying a test static HTML page.
 
-The following instructions tell you how to deploy a static HTML page using [v3 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v3). This version of the API allows you to push an app with no downtime without needing to use a [blue-green deployment](https://docs.cloudfoundry.org/devguide/deploy-apps/blue-green.html) plugin.
-
-If you are using [v2 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v2), refer to the documentation on [deploying a test static HTML page using Cloud Foundry API v2](get_started.html#deploy-a-test-static-html-page-using-cloud-foundry-api-v2).
+The following instructions tell you how to deploy a static HTML page using [v3 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v3). This version of the API allows you to push an app with no downtime without needing to use a [blue-green deployment tool](https://docs.cloudfoundry.org/devguide/deploy-apps/blue-green.html).
 
 <br>
 
 <%= warning_text('Cloud Foundry API v3 is still in beta.') %>
+
+Refer to the [Cloud Foundry documentation on the limitations of the v3 API](https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html#limitations) for more information.
+
+If you are using [v2 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v2), refer to the documentation on [deploying a test static HTML page using Cloud Foundry API v2](get_started.html#deploy-a-test-static-html-page-using-cloud-foundry-api-v2).
+
+If you are not sure which version of the Cloud Foundry API to use, contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
 
 1. To deploy an app, you must select a [target](deploying_apps.html#set-a-target). This is a combination of an [organisation](/orgs_spaces_users.html#organisations) and a [space](/orgs_spaces_users.html#spaces).
 

--- a/source/documentation/getting_started/get_started.erb
+++ b/source/documentation/getting_started/get_started.erb
@@ -215,7 +215,7 @@ If you are using [v2 of the Cloud Foundry API](https://github.com/cloudfoundry/c
 4. Create an app:
 
     ```
-    Cf v3-create-app APPNAME
+    cf v3-create-app APPNAME
     ```
 
     APPNAME is the unique name for your app that you specified in the manifest file.

--- a/source/documentation/getting_started/get_started.erb
+++ b/source/documentation/getting_started/get_started.erb
@@ -202,7 +202,8 @@ If you are using [v2 of the Cloud Foundry API](https://github.com/cloudfoundry/c
     applications:
     - name: APPNAME
       memory: 64M
-      buildpack: staticfile_buildpack
+      buildpacks:
+      - staticfile_buildpack
     ```
 
     where `APPNAME` is the unique name for your app. You can run `cf apps` to see apps which already exist.

--- a/source/documentation/getting_started/get_started.erb
+++ b/source/documentation/getting_started/get_started.erb
@@ -101,9 +101,13 @@ Space:          sandbox
 ```
 
 
-## Deploy a test static HTML page
+## Deploy a test static HTML page using Cloud Foundry API v2
 
 You can practice deploying an app by deploying a test static HTML page.
+
+The following instructions tell you how to deploy a static HTML page using [v2 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v2).
+
+If you are using [v3 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v3), refer to the documentation on [deploying a test static HTML page using Cloud Foundry API v3](get_started.html#deploy-a-test-static-html-page-using-cloud-foundry-api-v3).
 
 1. To deploy an app, you must select a [target](deploying_apps.html#set-a-target). This is a combination of an [organisation](/orgs_spaces_users.html#organisations) and a [space](/orgs_spaces_users.html#spaces).
 
@@ -150,6 +154,88 @@ You can practice deploying an app by deploying a test static HTML page.
 
     If you do not specify the app name in `cf push`, the name specified in the manifest file is used.
 
-    The static HTML page is now available at your [app domain](/orgs_spaces_users.html#regions).
+The static HTML page is now available at your [app domain](/orgs_spaces_users.html#regions).
 
 For a production app, you should read the [production checklist](deploying_apps.html#production-checklist).
+
+## Deploy a test static HTML page using Cloud Foundry API v3
+
+You can practice deploying an app by deploying a test static HTML page.
+
+The following instructions tell you how to deploy a static HTML page using [v3 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v3). This version of the API allows you to push an app with no downtime without needing to use a [blue-green deployment](https://docs.cloudfoundry.org/devguide/deploy-apps/blue-green.html).
+
+If you are using [v2 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v2), refer to the documentation on [deploying a test static HTML page using Cloud Foundry API v2](get_started.html#deploy-a-test-static-html-page-using-cloud-foundry-api-v2).
+
+<br>
+
+<%= warning_text('Cloud Foundry API v3 is still in beta.') %>
+
+1. To deploy an app, you must select a [target](deploying_apps.html#set-a-target). This is a combination of an [organisation](/orgs_spaces_users.html#organisations) and a [space](/orgs_spaces_users.html#spaces).
+
+    All orgs have a sandbox space for you to use when learning about the PaaS. When deploying a test static HTML page, you should target this sandbox space by running:
+
+    ```
+    cf target -o ORGNAME -s sandbox
+    ```
+
+    where `ORGNAME` is your org and `sandbox` is the name of the sandbox space.
+
+    If you deploy an app using the same name and target as an existing app, the original will be replaced. If you are not sure about where to deploy your app, consult the rest of your team or speak to the PaaS team by emailing [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
+
+2. In an empty directory, create an `index.html` file containing the following markup:
+
+    ```
+    <html>
+      <head>
+        <title>Static Site</title>
+      </head>
+      <body>
+        <p>Welcome to the static site!</p>
+      </body>
+    </html>
+    ```
+
+3. Create a `manifest.yml` file in the same directory as the `index.html` file. The manifest file tells Cloud Foundry what to do with your app.
+
+    ```
+    ---
+    applications:
+    - name: APPNAME
+      memory: 64M
+      buildpack: staticfile_buildpack
+    ```
+
+    where `APPNAME` is the unique name for your app. You can run `cf apps` to see apps which already exist.
+
+    The `memory` line tells the PaaS how much memory to allocate to the app.
+
+    A buildpack provides app framework and runtime support. For example, if your app was written in Ruby, you would use the `ruby_buildpack`. In this example, we use the `staticfile_buildpack` for the static HTML page.
+
+4. Create an app:
+
+    ```
+    Cf v3-create-app APPNAME
+    ```
+
+    APPNAME is the unique name for your app that you specified in the manifest file.
+
+    If you have an existing Cloud Foundry API v2 app and want to upgrade this app to use v3, you do not need to do this step.
+
+5.  Apply your created manifest file to your app:
+
+    ```
+    Cf v3-apply-manifest -f PATH_TO_MANIFEST
+    ```
+
+6. Push a zero downtime version of your app:
+
+    ```
+    cf v3-zdt-push APPNAME --wait-for-deploy-complete
+    ```
+    The command line will display a message when your app has finished deploying.
+
+The static HTML page is now available at your [app domain](/orgs_spaces_users.html#regions).
+
+For a production app, you should read the [production checklist](deploying_apps.html#production-checklist).
+
+Refer to the [Cloud Foundry documentation on rolling app deployments](https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html) for more information on v3 of the Cloud Foundry API.

--- a/source/documentation/getting_started/get_started.erb
+++ b/source/documentation/getting_started/get_started.erb
@@ -162,7 +162,7 @@ For a production app, you should read the [production checklist](deploying_apps.
 
 You can practice deploying an app by deploying a test static HTML page.
 
-The following instructions tell you how to deploy a static HTML page using [v3 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v3). This version of the API allows you to push an app with no downtime without needing to use a [blue-green deployment](https://docs.cloudfoundry.org/devguide/deploy-apps/blue-green.html).
+The following instructions tell you how to deploy a static HTML page using [v3 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v3). This version of the API allows you to push an app with no downtime without needing to use a [blue-green deployment](https://docs.cloudfoundry.org/devguide/deploy-apps/blue-green.html) plugin.
 
 If you are using [v2 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v2), refer to the documentation on [deploying a test static HTML page using Cloud Foundry API v2](get_started.html#deploy-a-test-static-html-page-using-cloud-foundry-api-v2).
 

--- a/source/documentation/troubleshooting/ssh.erb
+++ b/source/documentation/troubleshooting/ssh.erb
@@ -8,6 +8,10 @@ If you do run commands which will change the container temporarily, it's a good 
 
 SSH is enabled by default. In most cases, you will find that you can SSH directly to your app's container.
 
+<br>
+
+<%= warning_text('If you are using v3 of the Cloud Foundry API, you must run cf v3-ssh instead of cf ssh') %>
+
 1. Run:
 
     ```
@@ -85,7 +89,7 @@ To enable local port forwarding, you can use the parameter `-L`:
 cf ssh APPNAME -L LOCALPORT:REMOTEHOST:REMOTEPORT
 ```
 
-This will forward the `LOCALPORT` port on the local system to the given `REMOTEHOST` host and `REMOTEPORT` port on the application container side.  
+This will forward the `LOCALPORT` port on the local system to the given `REMOTEHOST` host and `REMOTEPORT` port on the application container side.
 
 Whenever a connection is made to this port, the connection is forwarded over the secure SSH channel, and a connection is made to the host and port `REMOTEHOST:REMOTEPORT` from the remote application container.
 


### PR DESCRIPTION
What
----
Added in content on the Cloud Foundry v3 API:

- add recreating the network policy for deploying a private app
- add content on deploying a static HTML page using the CF API v3
- rename content on deploying a static HTML page to deploying a static HTML page using the CF API v2
- add warning on cf ssh command for v3 of CF API

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Check that it fulfils https://www.pivotaltracker.com/story/show/165305947

Who can review
--------------

Anyone excluding Jon Glassman
