### PR TITLE
Make "Creating TCP tunnels" as subsection

### DIFF
--- a/source/documentation/troubleshooting/ssh.erb
+++ b/source/documentation/troubleshooting/ssh.erb
@@ -75,7 +75,7 @@ You can connect to a particular instance. For example, if you want to connect to
 cf ssh --app-instance-index 2
 ```
 
-## Creating TCP tunnels with SSH
+### Creating TCP tunnels with SSH
 
 You can use the [Conduit plugin](/guidance.html#conduit) to connect your local system to your remote backing service instance. If you instead want to manually create a TCP tunnel with SSH, refer to this section.
 


### PR DESCRIPTION
What
----

Because this is an `<h2>` it gets rendered as a separate section, but it
should actually appear under the "Connecting with SSH section".

How to review
-------------

* Check it matches the level of the other headings in this doc

Who can review
--------------

Not @richardtowers