### PR TITLE
Quick wins from Doc-a-thon

### DIFF
--- a/source/documentation/deploying_apps/buildpacks.md
+++ b/source/documentation/deploying_apps/buildpacks.md
@@ -12,7 +12,7 @@ Cloud Foundry uses buildpacks to provide runtime and framework support for appli
 
 We recommend using the standard buildpacks to maximise the support you will receive from GOV.UK PaaS. Using a custom buildpack or Docker image will mean additional setup and maintenance costs.
 
-Your responsibilities change depending on whether you use a standard buildpack, custom buildpack or a Docker image. Refer to the [responsibility model guidance](guidance.html#guidance-2-responsibility-model) for further information.
+Your responsibilities change depending on whether you use a standard buildpack, custom buildpack or a Docker image. Refer to the [documentation on knowing your responsibilities](responsibility_model.html#know-your-responsibilities) for further information.
 
 ### Buildpack language version updates
 

--- a/source/documentation/getting_started/get_started.erb
+++ b/source/documentation/getting_started/get_started.erb
@@ -100,6 +100,13 @@ Space:          sandbox
 
 ```
 
+### Failed to sign in
+
+If you make too many failed sign in attempts within a short amount of time, Cloud Foundry locks your account. While your account is locked, you cannot sign in.
+
+Wait 5 minutes for the account lock to expire before trying to sign into Cloud Foundry again.
+
+Make sure that no automated services, such as Jenkins, are trying to sign into Cloud Foundry using your account when your account is locked.
 
 ## Deploy a test static HTML page
 

--- a/source/documentation/guidance/pentest.md
+++ b/source/documentation/guidance/pentest.md
@@ -2,7 +2,7 @@
 
 ## Penetration testing
 
-[It is your responsibility](#responsibility-model) to penetration test your app to make sure it’s secure. Note that you can only penetration test your app; you cannot penetration test the platform.
+[It is your responsibility](responsibility_model.html#know-your-responsibilities) to penetration test your app to make sure it’s secure. Note that you can only penetration test your app; you cannot penetration test the platform.
 
 You must send the below information to [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) so that we are aware of your penetration test and can approve it.
 

--- a/source/documentation/managing_apps/scaling.md
+++ b/source/documentation/managing_apps/scaling.md
@@ -1,5 +1,3 @@
-# Managing apps
-
 ## Scaling
 
 You can manually scale your app to meet increasing demand. You can do this by:
@@ -47,4 +45,3 @@ This command increases the disk space limit for an app to 512 megabytes:
 ### Further information
 
 For more information, refer to the [Cloud Foundry documentation on using `cf scale` to scale an app](http://docs.cloudfoundry.org/devguide/deploy-apps/cf-scale.html) in the Cloud Foundry docs.
-

--- a/source/documentation/managing_apps/ssh.erb
+++ b/source/documentation/managing_apps/ssh.erb
@@ -1,3 +1,5 @@
+# Managing apps
+
 ## Connecting with SSH
 
 When you deploy an app to GOV.UK PaaS, it runs in a container, which is like a lightweight Linux virtual machine. Each app runs in its own isolated container.

--- a/source/managing_apps.html.md.erb
+++ b/source/managing_apps.html.md.erb
@@ -3,6 +3,7 @@ title: "Managing apps"
 weight: 80
 ---
 
+<%= partial 'documentation/managing_apps/ssh' %>
 <%= partial 'documentation/managing_apps/scaling' %>
 <%= partial 'documentation/managing_apps/quotas' %>
 <%= partial 'documentation/managing_apps/redirect_all_traffic' %>

--- a/source/troubleshooting.html.md.erb
+++ b/source/troubleshooting.html.md.erb
@@ -4,9 +4,6 @@ weight: 130
 ---
 
 <%= partial 'documentation/troubleshooting/index' %>
-<%= partial 'documentation/troubleshooting/ssh' %>
-<%= partial 'documentation/troubleshooting/lockouts' %>
-<%= partial 'documentation/troubleshooting/port' %>
 <%= partial 'documentation/troubleshooting/postgres' %>
 <%= partial 'documentation/troubleshooting/line-endings' %>
 <%= partial 'documentation/troubleshooting/tracing' %>


### PR DESCRIPTION
What
----

Made the following quick win changes from the PaaS Doc-a-thon session:

- Moved `Connecting with SSH` to under `Managing apps`
- Move `Failed login rate limit` to 'Sign into Cloud Foundry' and brought in line with style
- Removed `Troubleshooting > Port environment variable error` from docs
- Updated responsibility model link (`responsibility_model.html#know-your-responsibilities`) in Buildpacks and Penetration Testing sections

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Check it fulfils https://www.pivotaltracker.com/story/show/167699116

Who can review
--------------

Anyone except Jon Glassman
