### PR TITLE
Add -T flag to SSH guidance documentation

### DIFF
--- a/source/documentation/managing_apps/ssh.erb
+++ b/source/documentation/managing_apps/ssh.erb
@@ -88,7 +88,7 @@ The `cf ssh` command supports [local port forwarding](https://en.wikipedia.org/w
 To enable local port forwarding, you can use the parameter `-L`:
 
 ```
-cf ssh APPNAME -L LOCALPORT:REMOTEHOST:REMOTEPORT
+cf ssh APPNAME -T -L LOCALPORT:REMOTEHOST:REMOTEPORT
 ```
 
 This will forward the `LOCALPORT` port on the local system to the given `REMOTEHOST` host and `REMOTEPORT` port on the application container side.
@@ -135,7 +135,7 @@ For example, you can connect directly to the PostgreSQL service bound to an appl
  2. Create a SSH tunnel using the local port 6666:
 
     ```
-    cf ssh myapp -L 6666:HOST:PORT
+    cf ssh myapp -T -L 6666:HOST:PORT
     ```
 
     where HOST and PORT are the values you found in the previous step.


### PR DESCRIPTION
What
----

Tenants get confused when they tunnel and are ALSO given a
terminal, they try and use the tunnel terminal instead of opening a new
one (which the documentation says to do).

If we add `-T` then users will get a terminal which hangs, and be forced
to use a new terminal

How to review
-------------

Docs review

Who can review
--------------

Not @tlwr