### PR TITLE
Add documentation for accessing public S3 buckets

### DIFF
--- a/source/documentation/deploying_services/s3.md
+++ b/source/documentation/deploying_services/s3.md
@@ -44,6 +44,14 @@ cf create-service aws-s3-bucket default SERVICE_NAME -c '{"public_bucket":true}'
 ```
 where `SERVICE_NAME` is a unique descriptive name for this S3 bucket.
 
+#### Access objects in a public AWS S3 bucket
+
+Objects in a public S3 bucket will be available at:
+```
+https://BUCKET_NAME.s3.amazonaws.com/KEY
+```
+Where `BUCKET_NAME` is the `bucket_name` value available in [Environment Variables](/deploying_apps.html#system-provided-environment-variables) once you have [Bound an AWS S3 bucket to your app](/deploying_services/s3/#bind-an-aws-s3-bucket-to-your-app) and `KEY` is the key you gave to your object when performing `s3:PutObject`.
+
 ### Bind an AWS S3 bucket to your app
 
 You must bind the S3 bucket to your app so you can get credentials to use the [AWS S3 API](https://docs.aws.amazon.com/cli/latest/reference/s3api/) to read from and write to the bucket.

--- a/source/documentation/deploying_services/s3.md
+++ b/source/documentation/deploying_services/s3.md
@@ -44,14 +44,6 @@ cf create-service aws-s3-bucket default SERVICE_NAME -c '{"public_bucket":true}'
 ```
 where `SERVICE_NAME` is a unique descriptive name for this S3 bucket.
 
-#### Access objects in a public AWS S3 bucket
-
-Objects in a public S3 bucket will be available at:
-```
-https://BUCKET_NAME.s3.amazonaws.com/KEY
-```
-Where `BUCKET_NAME` is the `bucket_name` value available in [Environment Variables](/deploying_apps.html#system-provided-environment-variables) once you have [Bound an AWS S3 bucket to your app](/deploying_services/s3/#bind-an-aws-s3-bucket-to-your-app) and `KEY` is the key you gave to your object when performing `s3:PutObject`.
-
 ### Bind an AWS S3 bucket to your app
 
 You must bind the S3 bucket to your app so you can get credentials to use the [AWS S3 API](https://docs.aws.amazon.com/cli/latest/reference/s3api/) to read from and write to the bucket.
@@ -182,6 +174,16 @@ You can take different actions on an S3 bucket using the [AWS S3 API](https://do
 |List objects in S3 bucket|`s3:ListBucket`|`read-write`, `read-only`|
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
+
+### Access objects in a public AWS S3 bucket
+
+Once you have uploaded an object to a [public S3 bucket](#provision-a-public-aws-s3-bucket), you can find that object at: 
+```
+https://BUCKET_NAME.s3.amazonaws.com/KEY
+```
+where:
+- `BUCKET_NAME` is the bucket_name value in the bucket [environment variables](/deploying_apps.html#system-provided-environment-variables) 
+- `KEY` is the key you gave to the object when uploading that object to the bucket
 
 <h2 id="remove-the-service">Remove the service</h2>
 


### PR DESCRIPTION
What
----
Previously although it was described how to create public buckets, it was not described how to publicly access objects in those buckets.

How to review
-------------

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Check the content makes sense

Who can review
--------------

Anyone but me
