### PR TITLE
Correct reference to route service in private apps

### DIFF
--- a/source/documentation/deploying_apps/index.erb
+++ b/source/documentation/deploying_apps/index.erb
@@ -78,7 +78,8 @@ A possible exception to this is if your org is mature and has pre-existing space
 
 By default, all apps you deploy on Cloud Foundry are [publicly accessible](deploying_apps.html#deploying-public-apps) to everyone through the internet.
 
-If you need to restrict access to a public app, for example to whitelist IPs, you should refer to the documentation on [route services](/deploying_services/route_services/#route-services).
+If you need to restrict access to a public app, for example to implement basic auth, you should refer to the documentation on [route services](/deploying_services/route_services/#route-services).
+If you need to implement an IP whitelist, you should refer to the this [IP safelist app](https://github.com/alphagov/re-paas-ip-safelist-service).
 
 If you do not want your apps to be publicly accessible at all, you must deploy your apps on the `apps.internal` domain. A common use case for this is that you have multiple micro-services that make up an overall app, and those micro-services must only be accessible by other micro-services in the app.
 

--- a/source/documentation/deploying_apps/index.erb
+++ b/source/documentation/deploying_apps/index.erb
@@ -78,8 +78,9 @@ A possible exception to this is if your org is mature and has pre-existing space
 
 By default, all apps you deploy on Cloud Foundry are [publicly accessible](deploying_apps.html#deploying-public-apps) to everyone through the internet.
 
-If you need to restrict access to a public app, for example to implement basic auth, you should refer to the documentation on [route services](/deploying_services/route_services/#route-services).
-If you need to implement an IP whitelist, you should refer to the this [IP safelist app](https://github.com/alphagov/re-paas-ip-safelist-service).
+If you need to restrict access to a public app, for example to implement basic authentication, you should refer to the documentation on [route services](/deploying_services/route_services/#route-services).
+
+If you need to implement an IP whitelist, you should refer to this [IP whitelisting route service app](https://github.com/alphagov/re-paas-ip-safelist-service).
 
 If you do not want your apps to be publicly accessible at all, you must deploy your apps on the `apps.internal` domain. A common use case for this is that you have multiple micro-services that make up an overall app, and those micro-services must only be accessible by other micro-services in the app.
 


### PR DESCRIPTION
What
----

Previously, we pointed readers to the route services documentation to find out 
how to implement an IP whitelist in front of their apps. However, we don't
actually document that or support it as part of the platform. We actually
document how to implement basic auth.

Also adds a pointer to the `re-paas-ip-safelist-service`[1] app for 
implementing an IP whitelist.

[1] https://github.com/alphagov/re-paas-ip-safelist-service

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Copy review

Who can review
--------------
@jonathanglassman ?