### PR TITLE
Fix newline in cdn-route

### DIFF
--- a/source/documentation/deploying_services/use_a_custom_domain.erb
+++ b/source/documentation/deploying_services/use_a_custom_domain.erb
@@ -45,7 +45,7 @@ Once you create a CDN service instance, you cannot update or delete the instance
 1. Create an instance of the cdn-route service:
 
     ```
-    cf create-service cdn-route cdn-route SERVICE_INSTANCE
+    cf create-service cdn-route cdn-route SERVICE_INSTANCE \
     -c '{"domain": "SUBDOMAIN_LIST"}'
     ```
 


### PR DESCRIPTION
What
----
- This was getting interpreted as 2 separate commands when copying and
  pasting
- Other commands lower down use backslash so stay consistent

Who can review
--------------

Not me
