### PR TITLE
Elasticsearch docs - remove unnecessary/confusing wording

### DIFF
--- a/source/documentation/deploying_services/elasticsearch.md
+++ b/source/documentation/deploying_services/elasticsearch.md
@@ -2,8 +2,6 @@
 
 [Elasticsearch](https://www.elastic.co/) is an open source full-text RESTful search and analytics engine that allows you to store and search data.
 
-This implementation of Elasticsearch is a request-only private beta trial version of the backing service to gather feedback. This service may not be suitable for everyone. Contact the GOV.UK PaaS team at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) to try the Elasticsearch backing service.
-
 Before using Elasticsearch as your primary data store, you should assess if an [ACID-compliant](https://www.techopedia.com/definition/23949/atomicity-consistency-isolation-durability-acid) backing service such as [PostgreSQL](/deploying_services/postgresql/#postgresql) or [MySQL](/deploying_services/mysql/#mysql) would better meet your needs.
 
 <h2 id="set-up-the-service">Set up the service</h2>

--- a/source/documentation/deploying_services/elasticsearch.md
+++ b/source/documentation/deploying_services/elasticsearch.md
@@ -34,8 +34,6 @@ Before using Elasticsearch as your primary data store, you should assess if an [
 
     <div style="height:1px;font-size:1px;">&nbsp;</div>
 
-    You should use the Elasticsearch 6.x plan, unless there are compatibility issues between Elasticsearch 6.x and your app.
-
     All high availability (`ha`) plans are suitable for production.
 
     You should check the size of the available plans against your service needs.


### PR DESCRIPTION
What
----

- Remove private beta from elasticsearch page
- Remove note about compatibility because we only have 6.x plans now

How to review
-------------

Code review

Who can review
--------------

Not @tlwr