### PR TITLE
Add password reset for London

### DIFF
--- a/source/documentation/troubleshooting/password.md
+++ b/source/documentation/troubleshooting/password.md
@@ -1,5 +1,7 @@
 ## Forgotten passwords
 
-If you believe you have forgotten your GOV.UK PaaS credentials, you can request a password reset using the link below:
+If you believe you have forgotten your GOV.UK PaaS credentials, you can request a password reset using the links below:
 
-[Reset your password](https://login.cloud.service.gov.uk/forgot_password)
+[Reset your password - London Accounts](https://login.london.cloud.service.gov.uk/forgot_password)
+
+[Reset your password - Ireland Accounts](https://login.cloud.service.gov.uk/forgot_password)


### PR DESCRIPTION
What
----

There was only a link to the password reset for Ireland, this adds the link for London and clarifies which link leads to the relevant admin interface.


How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Code review

Who can review
--------------

Anyone
