### PR TITLE
Update tech docs template version and add contribution links

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
     fast_blank (1.0.0)
     fastimage (2.1.7)
     ffi (1.11.1)
-    govuk_tech_docs (2.0.3)
+    govuk_tech_docs (2.0.5)
       activesupport
       chronic (~> 0.10.2)
       middleman (~> 4.0)
@@ -64,7 +64,7 @@ GEM
       middleman-sprockets (~> 4.0.0)
       middleman-syntax (~> 3.0.0)
       nokogiri
-      openapi3_parser
+      openapi3_parser (~> 0.5.0)
       pry
       redcarpet (~> 3.3.2)
       sass
@@ -132,8 +132,8 @@ GEM
       middleman-core (>= 3.2)
       rouge (~> 2.0)
     mini_portile2 (2.4.0)
-    minitest (5.11.3)
-    multi_json (1.13.1)
+    minitest (5.12.2)
+    multi_json (1.14.1)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     openapi3_parser (0.5.2)
@@ -144,7 +144,7 @@ GEM
       tilt (>= 1.4.1, < 3)
     padrino-support (0.13.3.4)
       activesupport (>= 3.1)
-    parallel (1.17.0)
+    parallel (1.18.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -160,16 +160,16 @@ GEM
     ruby-enum (0.7.2)
       i18n
     sass (3.4.25)
-    sassc (2.2.0)
+    sassc (2.2.1)
       ffi (~> 1.9)
     servolux (0.13.0)
     sprockets (4.0.0.beta10)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    temple (0.8.1)
+    temple (0.8.2)
     thor (0.20.3)
     thread_safe (0.3.6)
-    tilt (2.0.9)
+    tilt (2.0.10)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
@@ -185,4 +185,4 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/config.rb
+++ b/config.rb
@@ -1,3 +1,9 @@
 require 'govuk_tech_docs'
 
+GovukTechDocs::SourceUrls.class_eval do
+  def report_issue_url
+    "mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk?subject=Problem with GOV.UK PaaS technical documentation"
+  end
+end
+
 GovukTechDocs.configure(self)

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -32,4 +32,9 @@ multipage_nav: true
 # Enable collapsible navigation in the sidebar
 collapsible_nav: true
 
+# Enable search
 enable_search: true
+
+# Show a block at the bottom of the page that links to the page source, so readers can easily contribute back to the documentation.
+show_contribution_banner: true
+github_repo: alphagov/paas-tech-docs/


### PR DESCRIPTION
What
----

1) Updated the tech docs template version to 2.0.5.

2) Activated the tech docs template feature that adds 'contribution' links on each page for users to:

- see the page in the PaaS GitHub repo
- report a problem with the page

There's an example of what this looks like at the bottom of the [Verify tech docs front page](https://www.docs.verify.service.gov.uk/#gov-uk-verify-technical-documentation).

To do this I've:

- added the relevant flag in the tech docs config file
- added code to config.rb to rewrite the 'report a problem' link so it's a mailto rather than a link to create a PR (similarly to Verify tech docs). This is to help users who want to report feedback without using GitHub.


How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Check it looks ok

Who can review
--------------

Anyone except Jon Glassman
