### PR TITLE
Update buildpacks documentation

### DIFF
--- a/source/documentation/deploying_apps/buildpacks.md
+++ b/source/documentation/deploying_apps/buildpacks.md
@@ -52,7 +52,8 @@ You can set application attribute options in a manifest.yml file in the director
 ```
 ---
   ...
-  buildpack: buildpack_URL
+  buildpacks:
+    - buildpack_URL
 ```
 
 >Command line options override the manifest; the option that overrides the custom buildpack attribute is `-b`.

--- a/source/documentation/deploying_apps/deploying_django.md
+++ b/source/documentation/deploying_apps/deploying_django.md
@@ -87,7 +87,8 @@ Before deploying a Django app, you must:
         applications:
         - name: my-app
           memory: 512M
-          buildpack: python_buildpack
+          buildpacks:
+            - python_buildpack
 
     where `my-django-app` is the name that will be used for the app within GOV.UK PaaS.
 

--- a/source/documentation/deploying_apps/deploying_node_js.md
+++ b/source/documentation/deploying_apps/deploying_node_js.md
@@ -31,7 +31,8 @@ This is the code for the example app we are going to use. It is a basic web serv
         - name: my-node-app
           command: node example.js
           memory: 256M
-          buildpack: nodejs_buildpack
+          buildpacks:
+            - nodejs_buildpack
 
     Replace ``my-node-app`` with a unique name for your app. (You can use ``cf apps`` to see apps which already exist).
 

--- a/source/documentation/deploying_apps/deploying_rails.md
+++ b/source/documentation/deploying_apps/deploying_rails.md
@@ -30,7 +30,8 @@ To deploy a Rails app that doesn't require a backing service:
         applications:
         - name: my-rails-app
           memory: 256M
-          buildpack: ruby_buildpack
+          buildpacks:
+            - ruby_buildpack
 
     Replace ``my-rails-app`` with a unique name for your app. (You can use ``cf apps`` to see apps which already exist).
 
@@ -78,7 +79,8 @@ These instructions are for deploying a Rails app with a PostgreSQL database, and
         applications:
         - name: my-rails-app
           memory: 256M
-          buildpack: ruby_buildpack
+          buildpacks:
+            - ruby_buildpack
 
     Replace ``my-rails-app`` with a unique name for your app. (You can use ``cf apps`` to see apps which already exist).
 

--- a/source/documentation/managing_apps/ssh.erb
+++ b/source/documentation/managing_apps/ssh.erb
@@ -56,7 +56,8 @@ Each instance of an app has an index number. Cloud Foundry assigns index numbers
     urls: myapp.london.cloudapps.digital
     last uploaded: Wed Dec 21 13:56:24 UTC 2016
     stack: cflinuxfs3
-    buildpack: staticfile_buildpack
+    buildpacks:
+      - staticfile_buildpack
 
     .   state     since                    cpu    memory        disk         details
     0   running   2016-12-21 02:27:11 PM   3.0%   7.1M of 64M   6.8M of 1G


### PR DESCRIPTION
What
----

This adjusts the documentation buildpacks syntax to avoid getting deprecation warnings:

`Deprecation warning: Use of 'buildpack' attribute in manifest is deprecated in favor of 'buildpacks'`.

Who can review
--------------

Any dev or tech writer.