### PR TITLE
Always fetch dependencies before building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ dependencies: ## Install dependencies
 	bundle install
 
 .PHONY: build
-build: ## Builds the project
+build: dependencies ## Builds the project
 	@echo "Run middleman..."
 	bundle exec middleman build $(VERBOSE_FLAG)
 	@echo "Copy additional files..."


### PR DESCRIPTION
What
----

The build is currently failing because it needs to run `bundle install`,
which `make test` currently doesn't run.

Making `build` depend on `dependencies` seems to be the most sensible
way of fixing this.

How to review
-------------

Code review is enough

Who can review
--------------

Not @richardtowers