### PR TITLE
Revert "Always fetch dependencies before building"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ dependencies: ## Install dependencies
 	bundle install
 
 .PHONY: build
-build: dependencies ## Builds the project
+build: ## Builds the project
 	@echo "Run middleman..."
 	bundle exec middleman build $(VERBOSE_FLAG)
 	@echo "Copy additional files..."


### PR DESCRIPTION
What
----

This reverts commit c22c0da8d753031ec9e3bee4a8ecd912bdc13db8.

It turns out the docker image we build that contains the dependencies doesn't have pip installed :rage:.

It's going to turn into a yak shave to get the build working properly,
so let's not even bother.

How to review
-------------

* Code review

Who can review
--------------

Not @richardtowers