### PR TITLE
Document that we give CORS permissions

### DIFF
--- a/source/documentation/deploying_services/s3.md
+++ b/source/documentation/deploying_services/s3.md
@@ -172,6 +172,8 @@ You can take different actions on an S3 bucket using the [AWS S3 API](https://do
 |Delete an object from S3 bucket|`s3:DeleteObject`|`read-write`|
 |Get AWS region of S3 bucket|`s3:GetBucketLocation`|`read-write`, `read-only`|
 |List objects in S3 bucket|`s3:ListBucket`|`read-write`, `read-only`|
+|Upload a [CORS policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html)|`s3:PutBucketCORS`|`read-write`|
+|Download a [CORS policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html)|`s3:GetBucketCORS`|`read-write`, `read-only`|
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 


### PR DESCRIPTION
What
----

I don't think this feature needs documenting in depth - it's much more
likely that someone will learn about this through the AWS docs or from
the docs of a library or framework they're using than from our docs.

It still makes sense to mention that we're giving bindings these
permissions though.

alphagov/paas-s3-broker#17 (and the bosh release follow ups) need to go first.

How to review
-------------

* Code review should be enough

Who can review
--------------

Not @richardtowers