### PR TITLE
Remove Google Analytics cookies

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -16,7 +16,7 @@ header_links:
   Support: https://www.cloud.service.gov.uk/support
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
-ga_tracking_id: UA-43115970-5
+ga_tracking_id: 
 
 # Table of contents depth – how many levels to include in the table of contents.
 # If your ToC is too long, reduce this number and we'll only show higher-level


### PR DESCRIPTION
What
----

We are removing the Google Analytics cookies and information relating to the use of Google Analytics whilst the cross gov.uk domain approach is being developed.


How to review
-------------

Code review
Spin up locally and check that no google analytics tracking is enabled.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected and check that no google analytics tracking is enabled.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Code review

Who can review
--------------

Anyone

