### PR TITLE
[#170596206] Add documentation for dotnet-core

### DIFF
--- a/source/deploying_apps.html.md.erb
+++ b/source/deploying_apps.html.md.erb
@@ -14,5 +14,6 @@ weight: 50
 <%= partial 'documentation/deploying_apps/deploying_node_js' %>
 <%= partial 'documentation/deploying_apps/deploying_django' %>
 <%= partial 'documentation/deploying_apps/deploying_java' %>
+<%= partial 'documentation/deploying_apps/deploying_dotnet' %>
 <%= partial 'documentation/deploying_apps/stopping_and_deleting_apps' %>
 <%= partial 'documentation/deploying_apps/deploying_docker_image' %>

--- a/source/documentation/deploying_apps/deploying_dotnet.md
+++ b/source/documentation/deploying_apps/deploying_dotnet.md
@@ -1,0 +1,61 @@
+## Deploy a .NET Core app
+
+This section covers how to deploy a .NET Core application to GOV.UK PaaS using the [dotnet-core buildpack](https://github.com/cloudfoundry/dotnet-core-buildpack).
+
+### Deploying an ASP.NET Core Web App
+
+This example will walk through creating a simple "Hello World" web application using [the `dotnet` command line interface](https://docs.microsoft.com/en-us/dotnet/core/tools/).
+The instructions assume you have already carried out the setup process explained in the [Get started](/get_started.html#get-started) section.
+
+1. Install the dotnet core command line interface (CLI) tools
+
+    See Microsoft's [documentation for instructions on how to do this](https://docs.microsoft.com/en-us/dotnet/core/tools/#installation).
+
+1. Create a new ASP.NET Core Web App using the dotnet CLI
+
+    ```bash
+    dotnet new webapp --name your-app-name
+    ```
+
+1. Change directory into your new application's directory
+
+    ```bash
+    cd your-app-name
+    ```
+
+1. Create a manifest to describe how your application should be deployed
+
+    ```yaml
+    ---
+    applications:
+    - name: your-app-name
+      buildpacks:
+      - dotnet_core_buildpack
+      memory: 256M
+    ```
+
+1. Pick a version of the .NET framework to target which is supported by the current buildpack
+
+    1. Run `cf buildpacks` and look at the filename for `dotnet_core_buildpack` to work out the version (for example, if the filename was `dotnet-core-buildpack-cflinuxfs3-v2.3.2.zip` the version of the buildpack would be `v2.3.2`).
+
+    1. Visit the buildpack's releases page, for example [https://github.com/cloudfoundry/dotnet-core-buildpack/releases/tag/v2.3.2](https://github.com/cloudfoundry/dotnet-core-buildpack/releases/tag/v2.3.2)
+    
+    1. Check the versions of `dotnet-sdk` supported by the buildpack - you should usually use the latest supported version, for example 3.0.100
+
+    1. Edit your `.csproj` file and change the contents of the `<TargetFramework>` element to the target framework corresponding to the supported framework version (for example, use `netcoreapp3.0` for a 3.0.x version of `dotnet-sdk`). See [Microsoft's documentation on supported target framework versions](https://docs.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-framework-versions).
+
+    1. Create a `buildpack.yml` file to specify which version of the framework the buildpack should use:
+
+        ```yaml
+        ---
+        dotnet-core:
+          sdk: 3.x
+        ```
+
+1. Push your application to GOV.UK PaaS
+
+    ```bash
+    cf push
+    ```
+
+You have now deployed your .NET core application. Your application should now be accessible over HTTPS from the URL provided in the output.

--- a/source/documentation/deploying_apps/deploying_java.md
+++ b/source/documentation/deploying_apps/deploying_java.md
@@ -7,7 +7,6 @@ This section covers how to deploy a Java application to GOV.UK PaaS using the [J
 If your java application can be packaged as a [self-executable JAR file](https://github.com/cloudfoundry/java-buildpack/blob/master/docs/container-java_main.md)  then deployment can be as simple as using `cf push -p [your-app].jar [your-app-name]`.
 
 This example will walk through creating a simple "Hello World" application that embeds the popular [Jetty webserver](https://www.eclipse.org/jetty/).
-s
 The instructions assume you have already carried out the setup process explained in the [Get started](/get_started.html#get-started) section.
 
 1. Create a directory for your Java application:


### PR DESCRIPTION
What
----

Sadly the dotnet buildpack is a bit tricky to use because you have to
specify which version of the framework you're using in two places - the
`.csproj` and `buildpack.yml`. This makes the documentation a bit
complicated, but I think this is the best we can do.

How to review
-------------

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Follow the instructions and check that they (a) make sense and (b) work
1. Review for technical correctness and style
1. Shepherd this through the tech writer two eye process

Who can review
--------------

Not @richardtowers