### PR TITLE
Deprecate the use of buildpack for manifests

### DIFF
--- a/source/documentation/deploying_apps/buildpacks.md
+++ b/source/documentation/deploying_apps/buildpacks.md
@@ -52,7 +52,8 @@ You can set application attribute options in a manifest.yml file in the director
 ```
 ---
   ...
-  buildpack: buildpack_URL
+  buildpacks:
+  - buildpack_URL
 ```
 
 >Command line options override the manifest; the option that overrides the custom buildpack attribute is `-b`.

--- a/source/documentation/deploying_apps/deploying_django.md
+++ b/source/documentation/deploying_apps/deploying_django.md
@@ -87,7 +87,8 @@ Before deploying a Django app, you must:
         applications:
         - name: my-app
           memory: 512M
-          buildpack: python_buildpack
+          buildpacks:
+          - python_buildpack
 
     where `my-django-app` is the name that will be used for the app within GOV.UK PaaS.
 

--- a/source/documentation/deploying_apps/deploying_node_js.md
+++ b/source/documentation/deploying_apps/deploying_node_js.md
@@ -31,7 +31,8 @@ This is the code for the example app we are going to use. It is a basic web serv
         - name: my-node-app
           command: node example.js
           memory: 256M
-          buildpack: nodejs_buildpack
+          buildpacks:
+          - nodejs_buildpack
 
     Replace ``my-node-app`` with a unique name for your app. (You can use ``cf apps`` to see apps which already exist).
 

--- a/source/documentation/deploying_apps/deploying_rails.md
+++ b/source/documentation/deploying_apps/deploying_rails.md
@@ -30,7 +30,8 @@ To deploy a Rails app that doesn't require a backing service:
         applications:
         - name: my-rails-app
           memory: 256M
-          buildpack: ruby_buildpack
+          buildpacks:
+          - ruby_buildpack
 
     Replace ``my-rails-app`` with a unique name for your app. (You can use ``cf apps`` to see apps which already exist).
 
@@ -78,7 +79,8 @@ These instructions are for deploying a Rails app with a PostgreSQL database, and
         applications:
         - name: my-rails-app
           memory: 256M
-          buildpack: ruby_buildpack
+          buildpacks:
+          - ruby_buildpack
 
     Replace ``my-rails-app`` with a unique name for your app. (You can use ``cf apps`` to see apps which already exist).
 


### PR DESCRIPTION
What
----
Updated sample `manifest.yml` files to replace the singular `buildpack:` with the plural `buildpacks:` and the nested collection. 

The use of `buildpack:` is [deprecated](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#deprecated) in favour of using

```
buildpacks:
- name_of_buildpack
```

Update docs relating to buildpacks, django, rails and node.


How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that the references to `buildpack` in sample `manifest.yml` files have been updated to use `buildpacks` instead. These are found under `/deploying_apps.html` and include instructions at `#specifying-buildpacks-in-the-manifest-file`, `#deploying-an-app`, `#deploying-with-a-postgresql-database`, `#deploy-a-node-js-app`, `#deploy-a-django-app`


Who can review
--------------

Only bevanloon worked on this so anyone else