### PR TITLE
Update non-PaaS postgres transfer guidance

### DIFF
--- a/source/documentation/deploying_services/postgresql.md
+++ b/source/documentation/deploying_services/postgresql.md
@@ -165,7 +165,7 @@ To move data from a non-PaaS PostgreSQL database to a PaaS PostgreSQL database:
 1. Run the following command in the CLI to export data from the non-PaaS database to an SQL data file:
 
     ```
-    pg_dump --host HOST_NAME --file DATA_FILE_NAME DATABASE_NAME
+    pg_dump --host HOST_NAME --file DATA_FILE_NAME --no-acl --no-owner DATABASE_NAME
     ```
 
     where:


### PR DESCRIPTION
What
----

@saliceti reported in x-gov slack that these flags were needed to
restore a paas database remotely

i have verified that without these flags, users see role errors (which
may be fine to ignore, but better to suppress them to make them less
confusing)

How to review
-------------

[Check flags exist](https://www.postgresql.org/docs/9.5/app-pgdump.html)

Who can review
--------------

Not @tlwr