### PR TITLE
fix link and use more inclusive/accurate language

### DIFF
--- a/source/documentation/deploying_services/postgresql.md
+++ b/source/documentation/deploying_services/postgresql.md
@@ -181,7 +181,7 @@ To move data from a non-PaaS PostgreSQL database to a PaaS PostgreSQL database:
 
     where `SERVICE_NAME` is a unique descriptive name for this service instance, and `DATA_FILE_NAME` is the SQL file created in the previous step.
 
-> You can only use [certain PostgreSQL extensions](/deploying_services/postgresql/#postgresql-extensions-whitelist).
+> You can only use [certain PostgreSQL extensions](/deploying_services/postgresql/#add-or-remove-extensions-for-a-postgresql-service-instance).
 
 #### PaaS to PaaS
 

--- a/source/documentation/deploying_services/use_a_custom_domain.erb
+++ b/source/documentation/deploying_services/use_a_custom_domain.erb
@@ -374,7 +374,7 @@ See the [How custom domains work](/deploying_services/use_a_custom_domain/#how-c
 
 ### Forwarding headers
 
-By default, our service broker configures the CDN to only forward the `Host` header to your app. You can safelist extra headers; in this example you can safelist the `Accept` and `Authorization` headers:
+By default, our service broker configures the CDN to only forward the `Host` header to your app. You can forward additional headers; in this example you can additionally forward the `Accept` and `Authorization` headers:
 
 ```bash
 cf update-service my-cdn-route \

--- a/source/documentation/deploying_services/use_a_custom_domain.erb
+++ b/source/documentation/deploying_services/use_a_custom_domain.erb
@@ -374,7 +374,7 @@ See the [How custom domains work](/deploying_services/use_a_custom_domain/#how-c
 
 ### Forwarding headers
 
-By default, our service broker configures the CDN to only forward the `Host` header to your app. You can whitelist extra headers; in this example you can whitelist the `Accept` and `Authorization` headers:
+By default, our service broker configures the CDN to only forward the `Host` header to your app. You can safelist extra headers; in this example you can safelist the `Accept` and `Authorization` headers:
 
 ```bash
 cf update-service my-cdn-route \


### PR DESCRIPTION
What
----

* Fix language to make it more inclusive, see https://www.ncsc.gov.uk/blog-post/terminology-its-not-black-and-white I have used safelist to be consistent with  https://github.com/alphagov/paas-ip-authentication-route-service but I don't mind if people prefer the NCSC suggested wording

* Fix previously broken anchor link

How to review
-------------

Run app locally
Anchor link on http://localhost:4567/deploying_services/postgresql/ show work

Who can review
--------------

anyone but me