### PR TITLE
Make logstash filters work with syslog agent

### DIFF
--- a/source/documentation/monitoring_apps/logs.md
+++ b/source/documentation/monitoring_apps/logs.md
@@ -46,7 +46,7 @@ You must set up [logstash](https://www.elastic.co/products/logstash) to process 
     filter {
         grok {
             # attempt to parse syslog lines
-            match => { "message" => "%{SYSLOG5424PRI}%{NONNEGINT:syslog_ver} +(?:%{TIMESTAMP_ISO8601:syslog_timestamp}|-) +(?:%{HOSTNAME:syslog_host}|-) +(?:%{NOTSPACE:syslog_app}|-) +(?:%{NOTSPACE:syslog_proc}|-) +(?:%{WORD:syslog_msgid}|-) +(?:%{SYSLOG5424SD:syslog_sd}|-|) +%{GREEDYDATA:syslog_msg}" }
+            match => { "message" => "(%{NONNEGINT:message_length} )?%{SYSLOG5424PRI}%{NONNEGINT:syslog_ver} (?:%{TIMESTAMP_ISO8601:syslog_timestamp}|-) +%{DATA:syslog_host} +%{UUID:cf_app_guid} +\[%{DATA:syslog_proc}\] +%{GREEDYDATA:syslog_msg}" }
             # if successful, save original `@timestamp` and `host` fields created by logstash
             add_field => [ "received_at", "%{@timestamp}" ]
             add_field => [ "received_from", "%{host}" ]

--- a/source/documentation/monitoring_apps/logs.md
+++ b/source/documentation/monitoring_apps/logs.md
@@ -43,6 +43,7 @@ You must set up [logstash](https://www.elastic.co/products/logstash) to process 
 1. Go to the __Logstash Filters__ page, and replace the code there with the following logstash filter code:
 
     ```
+    # updated 2020-07-01
     filter {
         grok {
             # attempt to parse syslog lines

--- a/source/documentation/monitoring_apps/logs.md
+++ b/source/documentation/monitoring_apps/logs.md
@@ -92,6 +92,14 @@ You must set up [logstash](https://www.elastic.co/products/logstash) to process 
                 value_split => ":"
                 remove_field => "router_keys"
             }
+
+            mutate {
+              convert => {
+                "[router][response_time]" => "float"
+                "[router][gorouter_time]" => "float"
+                "[router][app_index]" => "integer"
+              }
+            }
         }
 
         # Application logs


### PR DESCRIPTION
What
----

When we did a CF Upgrade, the format of logs shipped via syslog drains changed. The number of bytes of the message is now prepended to each log line.

Additionally, the logs now contain structured data `[tags@12345 key="val" key2="val2]` which contain additional context. We can use `kv` to split these into fields

I applied it to GOV.UK's Coronavirus Logit stack yesterday

How to review
-------------

Use [grokdebug](https://grokdebug.herokuapp.com/) to analyse the following pattern (from the PR) to check that everything parses correctly

grok
```
(%{NONNEGINT:message_length} )?%{SYSLOG5424PRI}%{NONNEGINT:syslog_ver} (?:%{TIMESTAMP_ISO8601:syslog_timestamp}|-) +%{DATA:syslog_host} +%{UUID:cf_app_guid} +\[%{DATA:syslog_proc}\] +- +(\[tags@%{NONNEGINT} +%{DATA:cf_tags}\])?%{GREEDYDATA:syslog_msg}
```

RTR
```
1544 <14>1 2020-06-30T20:39:27.28741+00:00 admin.public.paas-admin f1b1f3ec-3818-4c4f-868a-8bbcbe002c43 [RTR/0] - [tags@47450 __v1_type="LogMessage" app_id="f1b1f3ec-3818-4c4f-868a-8bbcbe002c43" app_name="paas-admin" component="route-emitter" deployment="tlwr" index="615757b6-f63d-400a-8f58-3295995f6fb8" instance_id="1" ip="10.0.48.5" job="router" organization_id="296c8805-6fdd-4e1e-8c47-7cb3c0b2b0a2" organization_name="admin" origin="gorouter" process_id="f1b1f3ec-3818-4c4f-868a-8bbcbe002c43" process_instance_id="396ee12e-9c13-4847-6275-33b1" process_type="web" source_type="RTR" space_id="8b0e9b96-1588-4d76-b512-3314f11ddf5a" space_name="public"] admin.tlwr.dev.cloudpipeline.digital - [2020-06-30T20:39:27.281504420Z] "GET /assets/6ddn8cvb82en96h8y5bk9buz9t.govuk.print.css HTTP/1.1" 304 0 0 "https://admin.tlwr.dev.cloudpipeline.digital/calculator?rangeStart=2020-06-01&rangeStop=2020-06-30&items%5B0%5D%5BplanGUID%5D=f4d4b95a-f55e-4593-8d54-3364c25798c4&items%5B0%5D%5BnumberOfNodes%5D=1&items%5B0%5D%5BmemoryInMB%5D=64" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36" "10.0.0.82:30868" "10.0.32.52:61142" x_forwarded_for:"213.86.153.214, 10.0.0.82" x_forwarded_proto:"https" vcap_request_id:"be088b85-9421-4a5b-7c6f-987f070c6b19" response_time:0.005768 gorouter_time:0.000193 app_id:"f1b1f3ec-3818-4c4f-868a-8bbcbe002c43" app_index:"1" x_b3_traceid:"f030993d3c0ed40c" x_b3_spanid:"f030993d3c0ed40c" x_b3_parentspanid:"-" b3:"f030993d3c0ed40c-f030993d3c0ed40c"
```

APP
```
900 <14>1 2020-06-30T20:39:27.287363+00:00 admin.public.paas-admin f1b1f3ec-3818-4c4f-868a-8bbcbe002c43 [APP/PROC/WEB/1] - [tags@47450 app_id="f1b1f3ec-3818-4c4f-868a-8bbcbe002c43" app_name="paas-admin" deployment="tlwr" index="995ca3a8-47bd-4f27-a553-d729203482e5" instance_id="1" ip="10.0.32.52" job="diego-cell" organization_id="296c8805-6fdd-4e1e-8c47-7cb3c0b2b0a2" organization_name="admin" origin="rep" process_id="f1b1f3ec-3818-4c4f-868a-8bbcbe002c43" process_instance_id="396ee12e-9c13-4847-6275-33b1" process_type="web" source_id="f1b1f3ec-3818-4c4f-868a-8bbcbe002c43" source_type="APP/PROC/WEB" space_id="8b0e9b96-1588-4d76-b512-3314f11ddf5a" space_name="public"] {"level":30,"time":1593549567287,"pid":9,"hostname":"396ee12e-9c13-4847-6275-33b1","req":{"method":"GET","url":"/assets/6ddn8cvb82en96h8y5bk9buz9t.govuk.print.css"},"res":{"status":304},"responseTime":1,"msg":"request completed"}
```

Who can review
--------------

Not @tlwr
