### PR TITLE
Update support links urls

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -13,7 +13,7 @@ header_links:
   Get started: https://www.cloud.service.gov.uk/get-started
   Features: https://www.cloud.service.gov.uk/features
   Documentation: /
-  Support: https://www.cloud.service.gov.uk/support
+  Support: https://admin.london.cloud.service.gov.uk/support
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
 ga_tracking_id: 

--- a/source/documentation/deploying_services/elasticsearch.md
+++ b/source/documentation/deploying_services/elasticsearch.md
@@ -191,7 +191,7 @@ Backups are taken every 2 hours. Data is retained for:
 - 2 days if you have a `tiny` plan
 - 14 days if you have a `small`, `medium` or `large` plan
 
-To restore data to an earlier state, you can visit the [GOV.UK PaaS support page](https://www.cloud.service.gov.uk/support) or contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
+To restore data to an earlier state, you can visit the [GOV.UK PaaS support page](https://admin.london.cloud.service.gov.uk/support) or contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
 
 ### View your Elasticsearch data using Kibana
 

--- a/source/documentation/deploying_services/use_a_custom_domain.erb
+++ b/source/documentation/deploying_services/use_a_custom_domain.erb
@@ -394,7 +394,7 @@ Note that forwarding headers has a negative impact on cacheability. See the [How
 
 #### Service creation timescales
 
-Service creation usually takes approximately one hour. Whilst a service is being created, you will see the status "create in progress" reported from commands like `cf service`. If it has not finished after 2 hours, we recommend that you check your DNS setup to make sure you completed the CNAME record creation correctly (see step seven). If this does not solve the issue, you may need to [contact support](https://www.cloud.service.gov.uk/support).
+Service creation usually takes approximately one hour. Whilst a service is being created, you will see the status "create in progress" reported from commands like `cf service`. If it has not finished after 2 hours, we recommend that you check your DNS setup to make sure you completed the CNAME record creation correctly (see step seven). If this does not solve the issue, you may need to [contact support](https://admin.london.cloud.service.gov.uk/support).
 
 #### CloudFront timescales for serving your origin from all locations
 
@@ -414,7 +414,7 @@ You may get the following error message when you try to update or delete a servi
 Server error, status code: 409, error code: 60016, message: An operation for service instance [name] is in progress.
 ```
 
-This happens because you can't do anything to a service instance while it's in a pending state. A CDN service instance stays pending until it detects the CNAME or ALIAS record. If this causes a problem for you, [contact support](https://www.cloud.service.gov.uk/support) to ask us to manually delete the pending instance.
+This happens because you can't do anything to a service instance while it's in a pending state. A CDN service instance stays pending until it detects the CNAME or ALIAS record. If this causes a problem for you, [contact support](https://admin.london.cloud.service.gov.uk/support) to ask us to manually delete the pending instance.
 
 ## How custom domains work
 
@@ -433,7 +433,7 @@ When you create your CDN distribution, CloudFront sets the default time-to-live 
 - 24 hours if you created your CDN distribution before 2019-08-12
 - 0 seconds if you created your CDN distribution after 2019-08-12
 
-While there is no mechanism for GOV.UK PaaS users to trigger a cache clear, [GOV.UK PaaS support](https://www.cloud.service.gov.uk/support) can. Cache invalidation is not instantaneous; Amazon recommends expecting a lag time of 10-15 minutes (more if there are many distinct endpoints).
+While there is no mechanism for GOV.UK PaaS users to trigger a cache clear, [GOV.UK PaaS support](https://admin.london.cloud.service.gov.uk/support) can. Cache invalidation is not instantaneous; Amazon recommends expecting a lag time of 10-15 minutes (more if there are many distinct endpoints).
 
 You can configure CloudFront to forward headers to your app, which causes CloudFront to cache multiple versions of an object based on the values in one or more request headers. See [CloudFront's documentation on headers and distributions](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/header-caching.html#header-caching-web) for more information. This means the more headers you forward the less caching will take place. Forwarding all headers means no caching will happen.
 

--- a/source/documentation/getting_started/get_started.erb
+++ b/source/documentation/getting_started/get_started.erb
@@ -2,7 +2,7 @@
 
 ## Get an account
 
-Your department, agency or team must have a GOV.UK PaaS account. This account is called an organisation, or [org](/orgs_spaces_users.html#organisations). Sign up for an org account at [https://www.cloud.service.gov.uk/signup](https://www.cloud.service.gov.uk/signup).
+Your department, agency or team must have a GOV.UK PaaS account. This account is called an organisation, or [org](/orgs_spaces_users.html#organisations). Sign up for an org account at [https://admin.london.cloud.service.gov.uk/support/sign-up](https://admin.london.cloud.service.gov.uk/support/sign-up).
 
 Once your department, agency or team has an org account, you will need a personal account. Ask your [org manager](/orgs_spaces_users.html#org-manager) to authorise the creation of your personal account.
 


### PR DESCRIPTION
To point them to the new url in PaaS admin

What
----

Update links to the [new support page](https://github.com/alphagov/paas-admin/pull/936)

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
2. Check the links take you to the right place

Who can review
--------------

not @kr8n3r 
