### PR TITLE
[#174438274] Read-only Postgres clarifications

### DIFF
--- a/source/documentation/deploying_services/postgresql.md.erb
+++ b/source/documentation/deploying_services/postgresql.md.erb
@@ -136,7 +136,7 @@ You can also bind your service instance with a read-only user to your app.
 
 2. Deploy your app in line with your normal deployment process.
 
-<%= warning_text('By default Postgres uses a schema called "public", on which all permissions are granted by to all.') %>
+<%= warning_text('By default Postgres uses a schema called "public", on which all permissions are granted to all.') %>
 
 We disable use of the public schema to read-only users via an event trigger. As
 a precaution, if you are very concerned about permissions, you should create a
@@ -165,6 +165,12 @@ cf conduit SERVICE_NAME -- psql
 ```
 
 where `SERVICE_NAME` is a unique descriptive name for this service instance.
+
+Conduit can be used with a `read-only` binding using the `-c` flag:
+
+```
+cf conduit SERVICE_NAME -c '{"read_only": true}' -- psql
+```
 
 Run `cf conduit --help` for more options, and refer to the [Conduit README file](https://github.com/alphagov/paas-cf-conduit/blob/master/README.md) for more information on how to use the plugin.
 

--- a/source/documentation/deploying_services/postgresql.md.erb
+++ b/source/documentation/deploying_services/postgresql.md.erb
@@ -136,6 +136,12 @@ You can also bind your service instance with a read-only user to your app.
 
 2. Deploy your app in line with your normal deployment process.
 
+<%= warning_text('By default Postgres uses a schema called "public", on which all permissions are granted by to all.') %>
+
+We disable use of the public schema to read-only users via an event trigger. As
+a precaution, if you are very concerned about permissions, you should create a
+new schema and use it, instead of relying on the default "public" schema.
+
 ### Connect to a PostgreSQL service from your app
 
 Your app must make a [Transport Layer Security (TLS)](https://en.wikipedia.org/wiki/Transport_Layer_Security) connection to the service. Some libraries use TLS by default, but others will need to be manually configured.


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/174438274)

What
----

Tell users that they may wish to reconsider using the `public` schema if they care deeply about permissions. Although in practice they shouldn't have to.

Tell users how to use conduit to connect to databases in a read-only fashion.


How to review
-------------

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. …

Who can review
--------------

Not @tlwr
