### PR TITLE
postgres: guidance on using read-only for old dbs

### DIFF
--- a/source/documentation/deploying_services/postgresql.md.erb
+++ b/source/documentation/deploying_services/postgresql.md.erb
@@ -174,6 +174,17 @@ cf conduit SERVICE_NAME -c '{"read_only": true}' -- psql
 
 Run `cf conduit --help` for more options, and refer to the [Conduit README file](https://github.com/alphagov/paas-cf-conduit/blob/master/README.md) for more information on how to use the plugin.
 
+The `read_only` flag is a new feature and may require one-time user action to
+work with databases that were created before the feature was introduced.
+
+If you encounter an error message like `ERROR:  permission denied for table
+my_table` when running `SELECT * FROM my_table` from a read-only conduit, then
+you should run `SELECT make_readable_generic()` from a non-read-only conduit.
+
+Permissions are automatically converged for read-only users when database
+objects are created, for example `CREATE TABLE my_table`, so the above action
+may not be necessary.
+
 <h2 id="amend-the-service">Amend the service</h2>
 
 ### Import and export bulk data to and from a PostgreSQL database


### PR DESCRIPTION
What
----

Document a current gotcha with read-only bindings

```
kevkeenoy_mhclg Sep 24th at 2:10 PM
Hello... seems like read-only conduits aren't working quite as expected - I opened one to one of our DBs but get...
rdsbroker_d2c440cc_eb3b_4a76_98f3_71b9906644b6=> select * from clients;
ERROR:  permission denied for table clients

tlwr_gds  4 days ago
Hi, yes I’ve seen this happen in other databases
Whenever a view/table/schema gets created (by a non-read-only user) we propagate permissions to the read-only group.
This means if you use a read-only user but permissions haven’t yet been propagated, then it does not have access to the table.
You can either (as a non-read-only user) run
SELECT make_readable_generic()
which is a function we use to allocate permissions
or just
CREATE SCHEMA foo;
DROP SCHEMA foo;
```
How to review
-------------

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. …

Who can review
--------------

@46bit 