### PR TITLE
Add isolation segment section to guidance page

### DIFF
--- a/source/documentation/guidance/isolation-segments.md
+++ b/source/documentation/guidance/isolation-segments.md
@@ -1,6 +1,6 @@
 ## Isolation segments
 
-### What are isolation segments
+### What isolation segments are
 
 Cells are the underlying servers that build and run your apps.
 GOV.UK PaaS schedules your apps on a large number of identical cells.
@@ -12,31 +12,31 @@ You can specify an isolation segments for a space, or for an organisation.
 
 #### Apps within a space
 
-When you specify an isolation segment for a space, then all apps in
+When you specify an isolation segment for a space, all apps in
 that space run on the isolation segment's cells, rather than on the normal
 cells.
 
 #### Apps within an organisation
 
-When you specify an isolation segment for an organisation, then all apps in
+When you specify an isolation segment for an organisation, all apps in
 that organisation run on the isolation segment's cells, rather than on the
 normal cells.
 
 ### What isolation segments are available
 
-Presently we offer one isolation segment:
+We currently offer one isolation segment:
 
 * `egress-restricted-1`
 
 #### Egress restricted
 
-When your apps run in an egress restricted isolation segment then they can:
+When your apps run in an egress restricted isolation segment, they can:
 
-* serve traffic from the internet (if you map [a public route](/deploying_apps.html#names-routes-and-domains))
-* serve traffic internally (if you map [a private route](/deploying_apps.html#deploying-private-apps))
+* serve traffic from the internet (if you map a [public route](/deploying_apps.html#names-routes-and-domains))
+* serve traffic internally (if you map a [private route](/deploying_apps.html#deploying-private-apps))
 * talk to other apps within the platform (if you set up [network policies](/deploying_apps.html#create-a-network-policy))
 
-But your apps cannot:
+However, your apps cannot:
 
 * talk to the internet
 * make external DNS requests
@@ -44,11 +44,10 @@ But your apps cannot:
 ### How you can use isolation segments
 
 If we have enabled an isolation segment for your organisation, and if you are
-an org manager, then you can change how your apps are scheduled using the
+an org manager, you can change how your apps are scheduled using the
 isolation segment.
 
-For example, the following commands will create a new space and ensure that,
-when you push an app within that space, it will run on a cell with egress
+For example, the following commands will create a new space and make sure that any app you push within that space will run on a cell with egress
 restrictions:
 
 ```
@@ -56,6 +55,6 @@ cf create-space my-locked-down-space
 cf set-space-isolation-segment my-locked-down-space egress-restricted-1
 ```
 
-Please contact us at
+Contact us at
 [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk)
 if you would like us to enable an isolation segment for your organisation.

--- a/source/documentation/guidance/isolation-segments.md
+++ b/source/documentation/guidance/isolation-segments.md
@@ -1,0 +1,61 @@
+## Isolation segments
+
+### What are isolation segments
+
+Cells are the underlying servers that build and run your apps.
+GOV.UK PaaS schedules your apps on a large number of identical cells.
+
+GOV.UK PaaS has other cells which are slightly different to the regular cells
+on which your apps run. These cells are called isolation segments.
+
+You can specify an isolation segments for a space, or for an organisation.
+
+#### Apps within a space
+
+When you specify an isolation segment for a space, then all apps in
+that space run on the isolation segment's cells, rather than on the normal
+cells.
+
+#### Apps within an organisation
+
+When you specify an isolation segment for an organisation, then all apps in
+that organisation run on the isolation segment's cells, rather than on the
+normal cells.
+
+### What isolation segments are available
+
+Presently we offer one isolation segment:
+
+* `egress-restricted-1`
+
+#### Egress restricted
+
+When your apps run in an egress restricted isolation segment then they can:
+
+* serve traffic from the internet (if you map [a public route](/deploying_apps.html#names-routes-and-domains))
+* serve traffic internally (if you map [a private route](/deploying_apps.html#deploying-private-apps))
+* talk to other apps within the platform (if you set up [network policies](/deploying_apps.html#create-a-network-policy))
+
+But your apps cannot:
+
+* talk to the internet
+* make external DNS requests
+
+### How you can use isolation segments
+
+If we have enabled an isolation segment for your organisation, and if you are
+an org manager, then you can change how your apps are scheduled using the
+isolation segment.
+
+For example, the following commands will create a new space and ensure that,
+when you push an app within that space, it will run on a cell with egress
+restrictions:
+
+```
+cf create-space my-locked-down-space
+cf set-space-isolation-segment my-locked-down-space egress-restricted-1
+```
+
+Please contact us at
+[gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk)
+if you would like us to enable an isolation segment for your organisation.

--- a/source/guidance.html.md.erb
+++ b/source/guidance.html.md.erb
@@ -5,4 +5,5 @@ weight: 120
 
 <%= partial 'documentation/guidance/pentest' %>
 <%= partial 'documentation/guidance/php-database' %>
+<%= partial 'documentation/guidance/isolation-segments' %>
 <%= partial 'documentation/guidance/plugins' %>


### PR DESCRIPTION
What
----

Add initial guidance on using isolation segments, for our initial isolation segment "egress-restricted-1"

We have structured the docs in this slightly elliptical way, because we foresee adding another isolation segment "high-cpu-1" or equivalent soon

_work in progress with @cmcnallygds_

How to review
-------------

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).