### PR TITLE
Change target dates for accessibility fixes

### DIFF
--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -80,15 +80,15 @@ We used manual and automated tests to look for issues such as:
 - inaccessible formatting in general
 - inaccessible language
 - inaccessible diagrams or images
-- lack of colour contrast for text, important graphics and controls
+- lack of colour contrast for text, important graphics and controls5
 - images not having meaningful alt text
 - problems when using assistive technologies such as screen readers and screen magnifiers
 
 ## What we’re doing to improve accessibility
 When we publish new content, we’ll make sure our use of images meets accessibility standards.
 
-We plan to fix the accessibility issues with the images by the end of 2020.
+We plan to fix the accessibility issues with the images by the end of March 2021.
 
-We plan to fix the other accessibility issues by updating our Technical Documentation Template by the end of 2020.
+We plan to fix the other accessibility issues by updating our Technical Documentation Template by the end of March 2021.
 
-This statement was prepared on 1 September 2020. It was last updated on 1 September 2020.
+This statement was prepared on 1 September 2020. It was last updated on 15 December 2020.


### PR DESCRIPTION

What
----

We were not able to fix all the tech doc template and image issues due to a lack of resources. We now aim to make the fixes by March 2021 rather than the end of this year so have changed dates to reflect this.

How to review
-------------

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
2. Check that dates are correct.

Who can review
--------------

not @cmcnallygds 