### PR TITLE
Drive our tenants towards using CF CLI v7

### DIFF
--- a/source/documentation/deploying_apps/index.erb
+++ b/source/documentation/deploying_apps/index.erb
@@ -156,18 +156,7 @@ You must create a [network policy](https://cli.cloudfoundry.org/en-US/cf/add-net
 cf add-network-policy PUBLIC_APPNAME --destination-app PRIVATE_APPNAME --protocol tcp --port 8080
 ```
 
-#### Recreate the network policy
-
-You must recreate the network policy every time you push your app if you’re using both:
-
-- [version 2 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v2)
-- a [blue-green deployment tool](https://docs.cloudfoundry.org/devguide/deploy-apps/blue-green.html) to reduce downtime
-
-This is because every time you push your app, the blue-green deployment tool creates a new version of the public app. The existing network policy will then no longer work.
-
-[Version 3 of the Cloud Foundry API](https://github.com/cloudfoundry/cloud_controller_ng/tree/master/docs/v3) deploys your app with zero downtime. You do not need to recreate the network policy every time you push your app.
-
-Contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) if you have any questions.
+<%= warning_text('If you are using Cloud Foundry CLI version 6 and the blue-green deploy plugin, you must recreate the network policy after each deployment') %>
 
 ## Data security classification
 

--- a/source/documentation/deploying_apps/production_checklist.md
+++ b/source/documentation/deploying_apps/production_checklist.md
@@ -1,6 +1,6 @@
 ## Deploy an app to production
 
-To deploy an app to a production environment, your department, agency or team must have a [paid account](/get_started.html#trial-and-paid-accounts) with the GOV.UK PaaS. 
+To deploy an app to a production environment, your department, agency or team must have a [paid account](/get_started.html#trial-and-paid-accounts) with the GOV.UK PaaS.
 
 Before you deploy an app to a production environment, you must set up a domain.
 
@@ -16,7 +16,6 @@ You must also:
 
 When you deploy an app to a production environment, you should:
 
-- use version 3 of the Cloud Foundry API to [zero-downtime deploy your app](/get_started.html#use-cloud-foundry-api-version-3)
-- use the [blue/green deployer plugin for Cloud Foundry](https://github.com/bluemixgaragelondon/cf-blue-green-deploy) to minimise app downtime if you are using version 2 of the Cloud Foundry API
+- [use zero downtime, rolling deploys](/get_started.html#deploying-with-zero-downtime)
 - [run more than one instance of your app](/managing_apps.html#scaling) to make sure your app is always available
 - select a high-availability plan for your app's [backing service](/deploying_services/#deploy-a-backing-or-routing-service) if your app uses a backing service

--- a/source/documentation/getting_started/get_started.erb
+++ b/source/documentation/getting_started/get_started.erb
@@ -32,7 +32,7 @@ However, your department, agency or team has a limited [quota](/managing_apps.ht
 - set up [custom domains](/deploying_services/use_a_custom_domain/#managing-custom-domains-using-the-cdn-route-service)
 - run [production apps](/deploying_apps.html#deploy-an-app-to-production) on the GOV.UK PaaS
 
-To set up custom domains and run production apps, your department, agency or team must have a paid account with GOV.UK PaaS. 
+To set up custom domains and run production apps, your department, agency or team must have a paid account with GOV.UK PaaS.
 
 To upgrade your department, agency or team's account from trial to paid, contact us by emailing [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
 
@@ -40,7 +40,7 @@ To upgrade your department, agency or team's account from trial to paid, contact
 
 GOV.UK PaaS is hosted on [Cloud Foundry](https://www.cloudfoundry.org/) [external link]. You must use the Cloud Foundry command line interface (CLI) to manage your apps hosted on the GOV.UK PaaS. To set it up:
 
-1. Download and install the [Cloud Foundry CLI](https://github.com/cloudfoundry/cli#downloads) for your platform.
+1. Download and install the [Cloud Foundry CLI version 7](https://github.com/cloudfoundry/cli/wiki/V7-CLI-Installation-Guide) for your platform.
 
 2. To check that it is installed correctly, run `cf -v` in the command line.
 
@@ -49,6 +49,8 @@ GOV.UK PaaS is hosted on [Cloud Foundry](https://www.cloudfoundry.org/) [externa
 Depending on your network configuration, you might need to set an `HTTP_PROXY` environment variable for the CLI to connect. Contact your network administrator for your configuration settings.
 
 Refer to the Cloud Foundry documentation on [using the Cloud Foundry CLI with a proxy server](https://docs.cloudfoundry.org/cf-cli/http-proxy.html) for more information.
+
+If you previously installed Cloud Foundry CLI version 6, you should [upgrade to Cloud Foundry CLI version 7](https://docs.cloudfoundry.org/cf-cli/v7.html)
 
 ## Sign in to Cloud Foundry
 
@@ -185,13 +187,11 @@ The static HTML page is now available at your [app domain](/orgs_spaces_users.ht
 
 For a production app, you should follow the [documentation on deploying an app to production](/deploying_apps.html#deploy-an-app-to-production).
 
-### Use Cloud Foundry API version 3
+### Deploying with zero downtime
 
-Version 3 allows you to push an app with no downtime without having to use a [blue-green deployment tool](https://docs.cloudfoundry.org/devguide/deploy-apps/blue-green.html).
+Cloud Foundry supports deploying applications with zero downtime by performing rolling deploys.
 
-<%= warning_text('Version 3 of the Cloud Foundry API is still in beta.') %>
-
-Refer to the [Cloud Foundry documentation on the limitations of API version 3](https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html#limitations) for more information.
+<%= warning_text('Rolling deploys with Cloud Foundry CLI version 6 are unsupported on GOV.UK PaaS.') %>
 
 1. To deploy an app, you must select a [target](deploying_apps.html#set-a-target). This is a combination of an [organisation](/orgs_spaces_users.html#organisations) and a [space](/orgs_spaces_users.html#spaces).
 
@@ -225,6 +225,7 @@ Refer to the [Cloud Foundry documentation on the limitations of API version 3](h
     applications:
     - name: APPNAME
       memory: 64M
+      instances: 3
       buildpacks:
       - staticfile_buildpack
     ```
@@ -233,33 +234,22 @@ Refer to the [Cloud Foundry documentation on the limitations of API version 3](h
 
     The `memory` line tells the PaaS how much memory to allocate to the app.
 
+    The `instances` line tells PaaS how many instances of the app to run.
+
     A buildpack provides app framework and runtime support. For example, if your app was written in Ruby, you would use the `ruby_buildpack`. In this example, we use the `staticfile_buildpack` for the static HTML page.
 
-4. Create an app:
+4. Perform a rolling deployment of your app:
 
     ```
-    cf v3-create-app APPNAME
-    ```
-
-    `APPNAME` is the unique name for your app that you specified in the manifest file.
-
-    You only need to run this command if you’re creating a new app that uses version 3 of the API.
-
-5.  Apply your created manifest file to your app:
-
-    ```
-    cf v3-apply-manifest -f PATH_TO_MANIFEST
-    ```
-
-6. Push a zero downtime version of your app:
-
-    ```
-    cf v3-zdt-push APPNAME --wait-for-deploy-complete
+    cf push APPNAME --strategy rolling
     ```
     The command line will display a message when your app has finished deploying.
+
+    Cloud Foundry will deploy 3 new instances of your application to handle new requests, allow connections to drain
+    from the existing instances, and then retire them.
 
 The static HTML page is now available at your [app domain](/orgs_spaces_users.html#regions).
 
 For a production app, you should follow the [documentation on deploying an app to production](/deploying_apps.html#deploy-an-app-to-production).
 
-Refer to the [Cloud Foundry documentation on rolling app deployments](https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html) for more information on version 3 of the Cloud Foundry API.
+Refer to the [Cloud Foundry documentation on rolling app deployments](https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html) for more information.

--- a/source/documentation/managing_apps/ssh.erb
+++ b/source/documentation/managing_apps/ssh.erb
@@ -12,24 +12,20 @@ If you make changes to your app's container during an SSH session, these changes
 
 Before you connect to an app's container using SSH, you must:
 
-- install the [Cloud Foundry Command Line Interface (CLI)](https://github.com/cloudfoundry/cli)
+- install the [Cloud Foundry Command Line Interface (CLI)](https://github.com/cloudfoundry/cli/wiki/V7-CLI-Installation-Guide)
 - set up the [correct SSH permissions](#manage-ssh-permissions) on the app and the space the app is in
 
-1. If you’re using version 3 of the Cloud Foundry API, run the following to start an SSH session:
-
-    ```
-    cf v3-ssh APPNAME
-    ```
-
-    where `APPNAME` is the name of the app.
-
-    If you are using version 2 of the Cloud Foundry API, run:
+1. Run the following to start an SSH session:
 
     ```
     cf ssh APPNAME
     ```
 
+    where `APPNAME` is the name of the app.
+
     The Cloud Foundry CLI will generate SSH keys for you.
+
+    <%= warning_text('If you are using Cloud Foundry CLI version 6, run `cf v3-ssh APPNAME') %>
 
 2. To match your SSH environment to your app's environment, run the following from within your SSH session shell:
 


### PR DESCRIPTION
What
----

CF CLI v6 is slowly being deprecated, and is in fact unsupported against the
latest CF API deployment at the time of writing. The only answer is to upgrade
to a supported version of CF CLI v7.

However our docs point people towards installing CF CLI v6, and talk about CF
CLI v7 and version 3 of the API as if they're experimental and maybe not quite
ready yet. This isn't true any more.

This commit makes it clear to tenants that they should be using CF CLI v7 where
at all possible.

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. …

Who can review
--------------
Anyone who knows about CF CLI v6/7 and CF API v2/3