### PR TITLE
Implement Google analytics with cookie consent preferences management

### DIFF
--- a/source/javascripts/application.js
+++ b/source/javascripts/application.js
@@ -1,1 +1,2 @@
 //= require govuk_tech_docs
+//= require cookies

--- a/source/javascripts/cookies.js
+++ b/source/javascripts/cookies.js
@@ -1,0 +1,191 @@
+(function (window) {
+  'use strict'
+
+  var cookieName = 'govuk-paas-cookie-policy',
+      cookieDomain = 'cloud.service.gov.uk',
+      cookieDuration = 365,
+      trackingId = 'UA-43115970-5';
+
+  // disable tracking by default
+  window['ga-disable-' + trackingId] = true;
+
+  hasCookiesPolicy() ? initAnalytics(hasAnalyticsConsent()) : initCookieBanner();
+  
+  function hasCookiesPolicy() {
+    return getCookie(cookieName)
+  }
+
+  function hasAnalyticsConsent () {
+    var consentCookie = JSON.parse(getCookie(cookieName));
+    return consentCookie ? consentCookie.analytics : false
+  }
+
+  function getCookie(name) {
+    var nameEQ = name + '='
+    var cookies = document.cookie.split(';')
+    for (var i = 0, len = cookies.length; i < len; i++) {
+      var cookie = cookies[i]
+      while (cookie.charAt(0) === ' ') {
+        cookie = cookie.substring(1, cookie.length)
+      }
+      if (cookie.indexOf(nameEQ) === 0) {
+        return decodeURIComponent(cookie.substring(nameEQ.length))
+      }
+    }
+    return null
+  }
+
+  function setCookie(name, values, options) {
+    if (typeof options === 'undefined') {
+      options = {}
+    }
+  
+    var cookieString = name + '=' + values
+    if (options.days) {
+      var date = new Date()
+      date.setTime(date.getTime() + (options.days * 24 * 60 * 60 * 1000))
+      cookieString = cookieString + '; expires=' + date.toGMTString() + ';domain=' + cookieDomain + '; path=/'
+    }
+    
+    if (document.location.protocol === 'https:') {
+      cookieString = cookieString + '; Secure';
+    }
+
+    document.cookie = cookieString
+  }
+
+  function initAnalytics(consent) {
+    if (!consent) {
+      return
+    }
+
+    // guard against being called more than once
+    if (!('GoogleAnalyticsObject' in window)) {
+  
+      window['ga-disable-'+ trackingId] = false;
+  
+      // Load GTM
+      loadGtmScript()
+      setupGtm()
+    }
+  }
+
+  // cookie banner functions
+
+  function initCookieBanner() {
+
+    var $skipLink = document.querySelector('.govuk-skip-link'), //insert after skip link for a11y
+        $cookieBanner = document.createElement('div');
+    
+    $cookieBanner.setAttribute('className','cookie-banner');
+    $cookieBanner.setAttribute('role','region');
+    $cookieBanner.setAttribute('aria-label','cookie-banner');
+    $cookieBanner.innerHTML = '<div class="cookie-banner__wrapper govuk-width-container">\
+      <h2 class="govuk-heading-m" id="cookie-banner__heading">\
+      Can we store analytics cookies on your device?</h2>\
+      <p class="govuk-body">Analytics cookies help us understand how our website is being used.</p>\
+      <div class="cookie-banner__buttons">\
+      <button class="govuk-button cookie-banner__button cookie-banner__button-accept" \
+      type="submit" data-accept-cookies="true" aria-describedby="cookie-banner__heading">\
+      Yes <span class="govuk-visually-hidden">, PaaS can store analytics cookies on your device</span></button>\
+      <button class="govuk-button cookie-banner__button cookie-banner__button-reject" \
+      type="submit" data-accept-cookies="false" aria-describedby="cookie-banner__heading">\
+      No <span class="govuk-visually-hidden">, PaaS cannot store analytics cookies on your device</span></button>\
+      <a class="govuk-link cookie-banner__link" href="https://www.cloud.service.gov.uk/cookies/">\
+      How PaaS uses cookies</a></div></div><div class="cookie-banner__confirmation govuk-width-container" tabindex="-1">\
+      <p class="cookie-banner__confirmation-message govuk-body">You can \
+      <a class="govuk-link" href="https://www.cloud.service.gov.uk/cookies/">change your cookie settings</a> at any time.</p>\
+      <button class="cookie-banner__hide-button govuk-link" data-hide-cookie-banner="true" role="link">\
+      Hide <span class="govuk-visually-hidden"> cookies message</span></button></div>';
+    
+    $skipLink.parentNode.insertBefore($cookieBanner, $skipLink.nextSibling);
+
+    var $hideLink = $cookieBanner.querySelector('button[data-hide-cookie-banner]'),
+        $acceptCookiesLink = $cookieBanner.querySelector('button[data-accept-cookies=true]'),
+        $rejectCookiesLink = $cookieBanner.querySelector('button[data-accept-cookies=false]');
+
+    $cookieBanner.style.display = 'block';
+
+    $cookieBanner.addEventListener('click', function(e) {
+      switch (e.target) {
+        case $rejectCookiesLink:
+          setBannerCookieConsent($cookieBanner, false);
+          break;
+        case $acceptCookiesLink:
+          setBannerCookieConsent($cookieBanner, true);
+          break;
+        case $hideLink:
+          hideCookieMessage($cookieBanner);
+          break;
+        default:
+          break;
+      }
+    });
+  }
+
+  function setBannerCookieConsent($container, analyticsConsent) {
+    var $cookieBannerConfirmationContainer = $container.querySelector('.cookie-banner__confirmation')
+
+    setCookie(cookieName, JSON.stringify({ 'analytics': analyticsConsent }), {days: cookieDuration});
+  
+    showBannerConfirmationMessage($container, analyticsConsent);
+    $cookieBannerConfirmationContainer.focus();
+  
+    if (analyticsConsent) { 
+      initAnalytics(true);
+    }
+  }
+
+  function showBannerConfirmationMessage($container, analyticsConsent) {
+    var messagePrefix = analyticsConsent ? 'You’ve accepted analytics cookies.' : 'You told us not to use analytics cookies.';
+    
+  
+    var $cookieBannerMainContent = $container.querySelector('.cookie-banner__wrapper'),
+        $cookieBannerConfirmationMessage = $container.querySelector('.cookie-banner__confirmation-message');
+  
+    $cookieBannerConfirmationMessage.insertAdjacentText('afterbegin', messagePrefix);
+    $cookieBannerConfirmationMessage.parentNode.style.display = 'block';
+    $cookieBannerMainContent.style.display = 'none'; 
+  }
+
+  function hideCookieMessage($container) {
+    $container.style.display = 'none'
+  }
+
+  // GTM functions
+  function loadGtmScript() {
+    var gtmScriptTag = document.createElement("script");
+    gtmScriptTag.type = "text/javascript"
+    gtmScriptTag.setAttribute("async", "true")
+    gtmScriptTag.setAttribute("src", "https://www.googletagmanager.com/gtag/js?id=" + trackingId)
+    document.documentElement.firstChild.appendChild(gtmScriptTag)
+  }
+
+  function setupGtm() {
+    // Pull dimensions vals from meta ; else all script/origin combinations have to be in the CSP	
+    window.dataLayer = window.dataLayer || [];	
+    function gtag(){dataLayer.push(arguments);}	
+    gtag('js', new Date());	
+  
+    var config = {
+      cookie_expires: cookieDuration * 24 * 60 * 60,
+      // docs get a relatively small number	
+      // of visits daily, so the default site speed	
+      // sample rate of 1% gives us too few data points.	
+      // Settings it to 30% gives us more data.	
+      siteSpeedSampleRate: 30,
+      anonymize_ip: true,
+      linker: {
+        domains: [
+          'cloud.service.gov.uk',
+          'admin.cloud.service.gov.uk',
+          'admin.london.cloud.service.gov.uk', 
+          'docs.cloud.service.gov.uk'
+        ]
+      }
+    };
+  
+    gtag('config', trackingId, config);
+  }
+
+})(window)

--- a/source/stylesheets/_cookie-banner.scss
+++ b/source/stylesheets/_cookie-banner.scss
@@ -1,0 +1,117 @@
+@import "govuk/components/button/button";
+
+.cookie-banner__wrapper {
+    @include govuk-responsive-padding(4, "top");
+    @include govuk-responsive-padding(5, "bottom");
+  }
+  
+  // component should only be shown if JS is available, by the cookieMessage JS, so hide by default
+  .cookie-banner {
+    display: none;
+  }
+  
+  .cookie-banner__buttons {
+    display: flex;
+    flex-wrap: wrap;
+  
+    @include govuk-media-query($from: tablet) {
+      flex-wrap: nowrap;
+    }
+  }
+  
+  .cookie-banner__button,
+  .cookie-banner__link {
+    vertical-align: baseline;
+  }
+  
+  .cookie-banner__button {
+    display: inline-block;
+    flex: 1 0;
+    padding-left: govuk-spacing(9);
+    padding-right: govuk-spacing(9);
+    margin-bottom: govuk-spacing(2);
+  
+    @include govuk-media-query($from: tablet) {
+      flex: 0 0 150px;
+      padding-left: govuk-spacing(2);
+      padding-right: govuk-spacing(2);
+      margin-bottom: govuk-spacing(1);
+    }
+  }
+  
+  .cookie-banner__button-accept {
+    margin-right: govuk-spacing(4);
+  }
+  
+  .cookie-banner__link {
+    @include govuk-font(19);
+    line-height: 1;
+    display: block;
+    width: 100%;
+    padding: 9px 0px 6px;
+  
+    @include govuk-media-query($from: tablet) {
+      display: inline;
+      width: auto;
+      margin-left: govuk-spacing(6);
+    }
+  }
+  
+  .cookie-banner__confirmation {
+    display: none;
+    position: relative;
+    padding: govuk-spacing(4) 0;
+  
+    @include govuk-media-query($from: desktop) {
+      padding: govuk-spacing(4);
+    }
+  
+    // This element is focused using JavaScript so that it's being read out by screen readers
+    // for this reason we don't want to show the default outline or emphasise it visually using `govuk-focused-text`
+    &:focus {
+      outline: none;
+    }
+  }
+  
+  .cookie-banner__confirmation-message,
+  .cookie-banner__hide-button {
+    display: block;
+  
+    @include govuk-media-query($from: desktop) {
+      display: inline-block;
+    }
+  }
+  
+  .cookie-banner__confirmation-message {
+    margin-right: govuk-spacing(4);
+  
+    @include govuk-media-query($from: desktop) {
+      max-width: 90%;
+    }
+  }
+  
+  .cookie-banner__hide-button {
+    @include govuk-font($size: 19);
+    color: $govuk-link-colour;
+    outline: 0;
+    border: 0;
+    background: none;
+    text-decoration: underline;
+    padding: govuk-spacing(0);
+    margin-top: govuk-spacing(2);
+    right: govuk-spacing(3);
+    cursor: pointer;
+  
+    @include govuk-media-query($from: desktop) {
+      margin-top: govuk-spacing(0);
+      position: absolute;
+      right: govuk-spacing(4);
+    }
+  }
+  
+  // Additions
+  
+  // Override margin-bottom, inherited from using .govuk-body class
+  .cookie-banner__confirmation-message {
+    margin-bottom: 0;
+  }

--- a/source/stylesheets/screen-old-ie.css.scss
+++ b/source/stylesheets/screen-old-ie.css.scss
@@ -2,3 +2,4 @@ $is-ie: true;
 $ie-version: 8;
 
 @import "govuk_tech_docs";
+@import "cookie-banner";

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -1,1 +1,2 @@
 @import "govuk_tech_docs";
+@import "cookie-banner";


### PR DESCRIPTION
What
----

Implementation of gtag.js Google analytics and the cookie banner consent model we have on product pages and admin
(alphagov/paas-admin#1123)

As the parent (tech-docs gem) doesn't have a slot for a cookie banner, we're injecting markup with javascript.
The built-in GA tracking options are also not suitable for us, so we're implementing the same tracking we have on our other estates.

It allows users to opt-in or opt-out and not see the banner again for a year

<img width="1328" alt="Screenshot 2020-12-23 at 22 00 33" src="https://user-images.githubusercontent.com/3758555/103040133-75cab180-456a-11eb-9a07-18eca8c75b6c.png">

How to review
-------------

- check out branch
- set `cookieDomain` to empty string for localhost test in `source/javascripts/cookies.js`
- preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
- if you haven't set a preference you will see a banner
- save a cookie preference
- check if have cookies stored (chrome: Option + ⌘ + J (on macOS), or Shift + CTRL + J (on Windows/Linux) - Application tab

Who can review
---------------

not @kr8n3r 
