### PR TITLE
Make it clear that private apps can communicate over TCP generally

### DIFF
--- a/source/documentation/deploying_apps/index.erb
+++ b/source/documentation/deploying_apps/index.erb
@@ -82,6 +82,8 @@ If you need to restrict access to a public app, for example to implement basic a
 
 If you do not want your apps to be publicly accessible at all, you must deploy your apps on the `apps.internal` domain. A common use case for this is that you have multiple micro-services that make up an overall app, and those micro-services must only be accessible by other micro-services in the app.
 
+Private apps can communicate over any TCP-based protocol. If you wish to use TLS, you are responsible for the keys, certificates, protocol versions, and ciphers involved.
+
 The following use case is that you have 2 apps to deploy:
 
 - a public app for your end users to interact with
@@ -141,7 +143,7 @@ where:
 
 - `PUBLIC_APPNAME` is the name of your public app
 - `ENVIRONMENT_VARIABLE_NAME` is the [environment variable](#environment-variables) your public app reads (for example `PRIVATE_APP_URL`)
-- `PRIVATE_APPNAME` is the name of your private app
+- `PRIVATE_APPNAME` is the name of your private app.
 
 ### Create a network policy
 


### PR DESCRIPTION
What
----
Let tenants know that it's not just HTTP they can use with private apps; they can use any TCP-based protocol. Caveat the use of TLS.

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Do you agree with what I've written?