### PR TITLE
Fix flag used in `cf marketplace` example

### DIFF
--- a/source/documentation/deploying_services/postgresql.md.erb
+++ b/source/documentation/deploying_services/postgresql.md.erb
@@ -13,7 +13,7 @@ To set up a PostgreSQL service:
 1. Run the following code in the command line to see what plans are available for PostgreSQL:
 
     ```
-    cf marketplace -s postgres
+    cf marketplace -e postgres
     ```
 
     Here is an example of the output you will see (the exact plans will vary):


### PR DESCRIPTION
What
----

Changed flag in documentation.

Current instructions lead to "Incorrect Usage: unknown flag `s'"

Have tested with `-e` (as per `--help`) and this seems to do what the documentation intended.

```
OPTIONS:
   -e              Show plan details for a particular service offering
   -b              Only show details for a particular service broker
   --no-plans      Hide plan information for service offering
```

How to review
-------------

Describe the steps required to test the changes.

1. Double-check the new flag is what was intended in the documentation.

Who can review
--------------

Anyone who familiar with the PaaS!
