### PR TITLE
Include location.hash in GA pageview

### DIFF
--- a/source/javascripts/cookies.js
+++ b/source/javascripts/cookies.js
@@ -169,6 +169,7 @@
   
     var config = {
       cookie_expires: cookieDuration * 24 * 60 * 60,
+      page_path: window.location.pathname + window.location.hash,
       // docs get a relatively small number	
       // of visits daily, so the default site speed	
       // sample rate of 1% gives us too few data points.	


### PR DESCRIPTION
What
----

In https://www.pivotaltracker.com/n/projects/1275640/stories/177950343 PA reported that pages with hashes in urls, like
https://docs.cloud.service.gov.uk/deploying_services/sqs/#remove-the-service were not showing up in GA.

This was because we weren't sending a modified string to pageview that included the location.hash.

This PR fixes that by concatenating pathname and hash strings.

How to review
-------------

- review code
- fix also deployed to https://paas-docs-fix.london.cloudapps.digital/

PA will be checking that data received is as expected

Who can review
--------------

not @kr8n3r 
