### PR TITLE
Implement GA event tracking

### DIFF
--- a/Staticfile
+++ b/Staticfile
@@ -1,0 +1,46 @@
+root: build
+status_codes:
+  400: /errors/generic.html
+  401: /errors/generic.html
+  402: /errors/generic.html
+  404: /errors/404.html
+  403: /errors/generic.html
+  405: /errors/generic.html
+  406: /errors/generic.html
+  407: /errors/generic.html
+  408: /errors/generic.html
+  409: /errors/generic.html
+  410: /errors/generic.html
+  411: /errors/generic.html
+  412: /errors/generic.html
+  413: /errors/generic.html
+  414: /errors/generic.html
+  415: /errors/generic.html
+  416: /errors/generic.html
+  417: /errors/generic.html
+  418: /errors/generic.html
+  420: /errors/generic.html
+  422: /errors/generic.html
+  423: /errors/generic.html
+  424: /errors/generic.html
+  426: /errors/generic.html
+  428: /errors/generic.html
+  429: /errors/generic.html
+  431: /errors/generic.html
+  444: /errors/generic.html
+  449: /errors/generic.html
+  450: /errors/generic.html
+  451: /errors/generic.html
+  500: /errors/generic.html
+  501: /errors/generic.html
+  502: /errors/generic.html
+  503: /errors/generic.html
+  504: /errors/generic.html
+  505: /errors/generic.html
+  506: /errors/generic.html
+  507: /errors/generic.html
+  508: /errors/generic.html
+  509: /errors/generic.html
+  510: /errors/generic.html
+  511: /errors/generic.html
+  

--- a/source/errors/404.html.md.erb
+++ b/source/errors/404.html.md.erb
@@ -1,0 +1,15 @@
+---
+title: Page not found
+hide_from_sitemap: true
+hide_in_navigation: true
+prevent_indexing: true
+layout: core
+---
+
+# Page not found
+
+If you typed the web address, check it is correct.
+
+If you pasted the web address, check you copied the entire address.
+
+[Contact the Platform as a Service team](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) if you believe you are seeing this message in error.

--- a/source/errors/generic.html.md.erb
+++ b/source/errors/generic.html.md.erb
@@ -1,0 +1,13 @@
+---
+title: Sorry, there is a problem with the service
+hide_from_sitemap: true
+hide_in_navigation: true
+prevent_indexing: true
+layout: core
+---
+
+# Sorry, there is a problem with the service
+
+Try again later.
+
+[Contact the Platform as a Service team](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) if you believe you are seeing this message in error.

--- a/source/javascripts/application.js
+++ b/source/javascripts/application.js
@@ -1,2 +1,3 @@
 //= require govuk_tech_docs
+//= require event-tracking
 //= require cookies

--- a/source/javascripts/cookies.js
+++ b/source/javascripts/cookies.js
@@ -68,6 +68,7 @@
       // Load GTM
       loadGtmScript()
       setupGtm()
+      window.EventTracking.init()
     }
   }
 

--- a/source/javascripts/event-tracking.js
+++ b/source/javascripts/event-tracking.js
@@ -1,0 +1,212 @@
+/* eslint-disable no-var, prefer-const */
+
+(function (EventTracking) {
+  var $bodyElement = document.querySelector('body')
+  var $mainHeading = $bodyElement.querySelector('h1')
+  var $searchinput = document.getElementById('search')
+  var inputDebounceTimer = null
+
+  EventTracking.init = function () {
+    // as we're tracking click al laorund the DOM, for the sake of efficiency,
+    // we only add 1 click event listener and do heavy lifting in functions below
+    // tech-docs template already adds ton of listeners so not goin overboard
+    $bodyElement.addEventListener('click', this.handleClickEvent.bind(this))
+    this.checkForErrorPage($mainHeading)
+
+    if ($searchinput) {
+      // fire event fucntion only after user stops typing (1sec gap)
+      $searchinput.addEventListener('input', function () {
+        clearTimeout(inputDebounceTimer)
+        inputDebounceTimer = setTimeout(function () {
+          this.trackSearch($searchinput.value)
+        }.bind(this), 1000)
+      }.bind(this))
+
+      // prevent from fuether events being sent when user moves away from the input
+      $searchinput.addEventListener('blur', function () {
+        clearTimeout(inputDebounceTimer)
+      })
+    }
+  }
+
+  EventTracking.handleClickEvent = function (e) {
+    var target = e.target
+    var isLink = e.target.nodeName === 'A'
+    var isTopNavLink = isLink && target.matches('.govuk-header__link')
+    // external links
+    var externalLinkRegex = /^(?=.*(http|mailto))(?:(?!cloud\.service\.gov\.uk).)*$/g
+    var isExternalLink = isLink && externalLinkRegex.test(target.getAttribute('href'))
+    // depending on the area clicked the target could be the button or the span inside it
+    var isNavToggleButton = target.matches('.collapsible__toggle') || target.parentNode.matches('.collapsible__toggle')
+    var isLinkwithFragment = isLink && target.getAttribute('href').indexOf('#') > -1
+    // links in navigation
+    var isLinkInNavigation = target.closest('.js-toc-list a')
+
+    // navigation links contain spans
+    var isSubLevelNavLink = target.matches('.collapsible__body a') || target.parentNode.matches('.collapsible__body a')
+    // not all <li> or <a> that are top level have classes
+    var isTopLevelNavLink = target.matches('.js-toc-list > ul > li > a') || target.parentNode.matches('.js-toc-list > ul > li > a')
+
+    if (isNavToggleButton) {
+      this.trackToggleButtonCLick(target)
+    }
+
+    if (isTopNavLink) {
+      this.trackTopNavLinkClick(target)
+    }
+
+    if (isExternalLink) {
+      this.trackExternalLinkClick(target)
+    }
+
+    if (isLinkwithFragment && !isLinkInNavigation) {
+      this.trackLinkWithFragmentClick(target)
+    }
+
+    if (isSubLevelNavLink) {
+      this.trackSubNavLinkClick(target)
+    }
+
+    if (isTopLevelNavLink) {
+      this.trackTopLevelNavLinkClick(target)
+    }
+  }
+
+  EventTracking.trackTopNavLinkClick = function (element) {
+    var eventParams = {}
+    var eventAction = 'Top Menu'
+
+    eventParams.event_category = 'Navigation'
+    eventParams.event_label = element.textContent
+
+    this.sendEvent(eventAction, eventParams)
+  }
+
+  EventTracking.trackExternalLinkClick = function (element) {
+    var eventParams = {}
+    var eventAction = element.textContent
+
+    eventParams.event_category = 'External Link Clicked'
+    eventParams.event_label = element.getAttribute('href')
+
+    this.sendEvent(eventAction, eventParams)
+  }
+
+  EventTracking.trackLinkWithFragmentClick = function (element) {
+    var eventParams = {}
+    var eventAction = 'Anchor Link'
+
+    eventParams.event_category = 'Click'
+    eventParams.event_label = element.textContent
+
+    this.sendEvent(eventAction, eventParams)
+  }
+
+  EventTracking.trackToggleButtonCLick = function (element) {
+    var targetText = element.textContent ? element.textContent : element.parentNode.textContent
+    var eventParams = {}
+    var eventAction = 'Side Bar Arrow Click '
+    // text toggle (expand/collpase is handle by the template)
+    // when we listen to the event, the text has already been tooggled
+    //  event label required to send:
+    // if collapsed, on click fire 'Side Bar Arrow Click Open'
+    // if expanded, on click fire 'Side Bar Arrow Click Close'
+    var isCollapsedState = targetText.split('Collapse').length > 1
+    var isExpandedSTate = targetText.split('Expand').length > 1
+
+    eventParams.event_category = 'Navigation'
+
+    if (isCollapsedState) {
+      eventParams.event_label = (targetText.split('Collapse')[1]).trim()
+      eventAction += 'Open'
+    }
+
+    if (isExpandedSTate) {
+      eventParams.event_label = (targetText.split('Expand')[1]).trim()
+      eventAction += 'Close'
+    }
+
+    this.sendEvent(eventAction, eventParams)
+  }
+
+  EventTracking.trackSubNavLinkClick = function (element) {
+    var eventParams = {}
+    var eventAction = 'Side Bar Navigation'
+
+    eventParams.event_category = 'Navigation'
+    eventParams.event_label = 'Sub | ' + (element.textContent ? element.textContent : element.parentNode.textContent)
+
+    this.sendEvent(eventAction, eventParams)
+  }
+
+  EventTracking.trackTopLevelNavLinkClick = function (element) {
+    var eventParams = {}
+    var eventAction = 'Side Bar Navigation'
+
+    eventParams.event_category = 'Navigation'
+    eventParams.event_label = 'Heading | ' + (element.textContent ? element.textContent : element.parentNode.textContent)
+
+    this.sendEvent(eventAction, eventParams)
+  }
+
+  EventTracking.checkForErrorPage = function (identifier) {
+    // GA needs strings for status code as event labels
+    var errorPagesArray = [
+      {
+        title: 'Page not found',
+        statusCode: '404'
+      },
+      {
+        title: 'Sorry, there is a problem with the service',
+        statusCode: '500'
+      }
+    ]
+    if (!identifier) return
+
+    var errorPageData = errorPagesArray.filter(function (o) {
+      return o.title === identifier.textContent
+    })
+
+    if (errorPageData[0]) {
+      this.sendEvent(errorPageData[0].statusCode, { event_category: 'Error' })
+    }
+  }
+
+  EventTracking.trackSearch = function (query) {
+    var resultCount = document.getElementById('search-results-title').textContent
+
+    this.sendEvent('Number of results', {
+      event_category: 'Site Search',
+      event_label: resultCount
+    })
+
+    this.sendEvent('Query', {
+      event_category: 'Site Search',
+      event_label: this.PIIfy(query)
+    })
+  }
+
+  EventTracking.sendEvent = function (eventAction, options) {
+    window.dataLayer = window.dataLayer || []
+    var gtag = function () {
+      dataLayer.push(arguments)
+    }
+
+    gtag('event', eventAction, options)
+  }
+
+  EventTracking.PIIfy = function (string) {
+    var strippedString
+    var EMAIL_PATTERN = /[^\s=/?&]+(?:@|%40)[^\s=/?&]+/g
+    var NUMBER_PATTERN = /0|1|2|3|4|5|6|7|8|9/g
+
+    strippedString = string
+      .replace(
+        NUMBER_PATTERN, '[number]'
+      ).replace(
+        EMAIL_PATTERN, '[email]'
+      )
+
+    return strippedString
+  }
+}(window.EventTracking = window.EventTracking || {}))


### PR DESCRIPTION
What
----

Send interaction events to GA if the user has consented to analytics cookies.

As we cannot add data tracking attributes to targeted elements, all of the targeting logic is done as part of the script.

This adds logic to determine when the following elements are interacted with:

- top level navigation
- external links
- anchor links (links with #)
- search
- sidebar navigation (table of contents):
    - top level item
    - sub level item
    - toggle collapse/expand button

Additionally, we send events for 404 and 500 pages.

Follows on from https://github.com/alphagov/paas-product-pages/pull/120 and https://github.com/alphagov/paas-admin/pull/1423

How to review
-------------

- run locally or visit https://paas-tech-docs-ga-test.london.cloudapps.digital/
- if you have Omnibug extension, you can view events in the console (PA is verifying sent data separately)
- review code

Who can review
--------------

not @kr8n3r 
