### PR TITLE
Update search GA event

### DIFF
--- a/source/javascripts/event-tracking.js
+++ b/source/javascripts/event-tracking.js
@@ -175,12 +175,7 @@
   EventTracking.trackSearch = function (query) {
     var resultCount = document.getElementById('search-results-title').textContent
 
-    this.sendEvent('Number of results', {
-      event_category: 'Site Search',
-      event_label: resultCount
-    })
-
-    this.sendEvent('Query', {
+    this.sendEvent(resultCount, {
       event_category: 'Site Search',
       event_label: this.PIIfy(query)
     })


### PR DESCRIPTION
What
----

Consolidate 2 events into one as per https://www.pivotaltracker.com/n/projects/1275640/stories/178674295

![Screenshot 2021-06-25 at 15 22 48](https://user-images.githubusercontent.com/3758555/123439559-c8446380-d5c9-11eb-9bcc-ee04337d10d3.png)
![Screenshot 2021-06-25 at 15 27 05](https://user-images.githubusercontent.com/3758555/123439630-d6927f80-d5c9-11eb-9a19-5dddb8ef9387.png)


How to review
-------------

- see https://paas-tech-docs-search-event.london.cloudapps.digital/ 
or run locally (update `cookieDomain` in cookies.js to empty string

- accept cookies
- use Omnibug chrome extension to test

Who can review
--------------

anyone
