### PR TITLE
Use full service name in the `title`

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -4,6 +4,7 @@ host: https://docs.cloud.service.gov.uk
 # Header-related options
 show_govuk_logo: true
 service_name: Platform as a Service
+full_service_name: GOV.UK Platform as a Service
 service_link: /
 phase:
 


### PR DESCRIPTION
What
----

Tech docs template allows for a [`full_service_name`](https://tdt-documentation.london.cloudapps.digital/configure_project/global_configuration/#full-service-name)
that gets used in the title. We keep the `service_name` for use in the header, as header comes with the GOV.UK logo already

Before

![Screenshot 2021-07-14 at 09 35 17](https://user-images.githubusercontent.com/3758555/125591131-400c5966-b68b-4a35-b949-5d821df5b336.png)

After

![Screenshot 2021-07-14 at 09 31 59](https://user-images.githubusercontent.com/3758555/125591170-5d7172c1-7bb0-4eea-b43d-5ba7a2bdd293.png)



How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.

Who can review
--------------
not @kr8n3r 

