### PR TITLE
[#178671156] add Permissions-Policy header

### DIFF
--- a/Staticfile
+++ b/Staticfile
@@ -1,4 +1,5 @@
 root: build
+location_include: includes/*.conf
 status_codes:
   400: /errors/generic.html
   401: /errors/generic.html

--- a/nginx/conf/includes/custom_headers.conf
+++ b/nginx/conf/includes/custom_headers.conf
@@ -1,0 +1,1 @@
+add_header Permissions-Policy "interest-cohort=()";


### PR DESCRIPTION
as per https://github.com/alphagov/govuk-rfcs/pull/142

What
----

Added Staticfile directive to hopefully inject `nginx/conf/includes/custom_headers.conf` into the main `location` section of the generated nginx conf.

See https://docs.cloudfoundry.org/buildpacks/staticfile/index.html#staticfile for documentation on this

Is the `redirect/nginx.conf` file in here actually used at all? If not might we be able to remove it because it's pretty confusing..

How to review
-------------

See test app pushed to https://paas-tech-docs-ris.cloudapps.digital, observe headers served.