### PR TITLE
Correct broken link to information-assurance

### DIFF
--- a/source/documentation/deploying_services/index.md
+++ b/source/documentation/deploying_services/index.md
@@ -84,6 +84,6 @@ You can store data classified up to ‘official’ on the GOV.UK PaaS.
 
 You cannot store data classified ‘secret‘ or ‘top secret‘ on the GOV.UK PaaS.
 
-Refer to the [information assurance page](https://www.cloud.service.gov.uk/ia) for more information on the assurance process.
+Refer to the [information assurance page](https://www.cloud.service.gov.uk/information-assurance/) for more information on the assurance process.
 
 Refer to the [GOV.UK page on government security classifications](https://www.gov.uk/government/publications/government-security-classifications) for more information on these classifications.


### PR DESCRIPTION
Colin from DfE reported a broken link in our documentation

What
----

link to IA page is broken following from restructuring of content

Describe what you have changed and why.

new link

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. …

Who can review
--------------

anyone but @pauldougan 