### PR TITLE
Make docs more accessible

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,7 @@ GEM
     fast_blank (1.0.0)
     fastimage (2.2.4)
     ffi (1.15.3)
-    govuk_tech_docs (2.3.0)
+    govuk_tech_docs (2.4.2)
       autoprefixer-rails (~> 10.2)
       chronic (~> 0.10.2)
       middleman (~> 4.0)
@@ -64,8 +64,8 @@ GEM
       middleman-syntax (~> 3.2.0)
       nokogiri
       openapi3_parser (~> 0.9.0)
-      redcarpet (~> 3.5.0)
-    haml (5.2.1)
+      redcarpet (~> 3.5.1)
+    haml (5.2.2)
       temple (>= 0.8.0)
       tilt
     hamster (3.0.0)

--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Accessibility statement for the GOV.UK PaaS public-facing documentation
-last_reviewed_on: 2020-09-01
+last_reviewed_on: 2021-07-30
 review_in: 6 months
 hide_in_navigation: true
 ---
@@ -58,4 +58,4 @@ We last tested this website for accessibility issues in March 2021.
 When we publish new content, we’ll make sure it meets accessibility standards.
 
 
-This statement was prepared on 1 September 2020. It was last updated on 18 March 2021.
+This statement was prepared on 1 September 2020. It was last updated on 28 June 2021.


### PR DESCRIPTION
What
----

- update the tech-docs-gem to version 2.4.2 which [brings in accessibility fixes](https://github.com/alphagov/tech-docs-gem/blob/master/CHANGELOG.md)
- update the change date when we did the last change in #390 and update review date to todays date

How to review
-------------

- run local to check app works

Who can review
--------------

not @kr8n3r 
