### PR TITLE
Add section on static IP addresses

### DIFF
--- a/source/documentation/guidance/static-egress-ips.md
+++ b/source/documentation/guidance/static-egress-ips.md
@@ -1,0 +1,9 @@
+## Static egress IP addresses
+
+To locate the GOV.UK PaaS static egress Internet Protocol (IP) addresses, [log in to your GOV.UK PaaS account](https://www.cloud.service.gov.uk/sign-in/) and go to the relevant link (depending on where your account is located):
+
+- [London static egress IP addresses](https://admin.london.cloud.service.gov.uk/support/static-ip)
+- [Ireland static egress IP addresses](https://admin.cloud.service.gov.uk/support/static-ip)
+
+These are also available from the footer of our website for easy access when you are logged in.
+

--- a/source/documentation/monitoring_apps/logs.md
+++ b/source/documentation/monitoring_apps/logs.md
@@ -168,7 +168,7 @@ Contact us by emailing [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailt
 
 By default, Logit allows anyone on the internet to send logs to your ELK stack. You can set up Logit to make sure that your ELK stack only receives logs from GOV.UK PaaS.
 
-1. Contact GOV.UK PaaS support at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) for a list of syslog drain egress IP addresses.
+1. Read [Static egress IP addresses](/guidance.html#static-egress-ip-addresses) for a list of syslog drain IP addresses.
 1. Send these IP addresses to Logit support at [https://logit.io/contact-us](https://logit.io/contact-us) and ask that your ELK stack only receives log messages from these addresses.
 
 ### Further information

--- a/source/guidance.html.md.erb
+++ b/source/guidance.html.md.erb
@@ -7,3 +7,4 @@ weight: 120
 <%= partial 'documentation/guidance/php-database' %>
 <%= partial 'documentation/guidance/isolation-segments' %>
 <%= partial 'documentation/guidance/plugins' %>
+<%= partial 'documentation/guidance/static-egress-ips' %>


### PR DESCRIPTION
What
----

Signpost links to paas-admin pages where ip addresses are viewable

Why here? because users search our documentation, but we don't want them to be easily publicly available.

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.

Who can review
--------------

not @kr8n3r 
