### PR TITLE
Update the docs on upgrading Redis instances

### DIFF
--- a/source/documentation/deploying_services/redis.md
+++ b/source/documentation/deploying_services/redis.md
@@ -167,8 +167,8 @@ Run `cf conduit --help` for more options, and refer to the [Conduit README file]
 
 ### Upgrade Redis service plan
 
-Our service broker does not currently allow to upgrade Redis services in
-place. In order to upgrade your Redis service, please execute the following
+Our service broker does not currently allow us to upgrade Redis services in
+place. To upgrade your Redis service, perform the following
 steps:
 
 1. `cf create-service redis DESIRED_PLAN NEW_REDIS_NAME`
@@ -177,7 +177,7 @@ steps:
 4. `cf restage APP_NAME`
 5. `cf delete-service OLD_REDIS_NAME`
 
-You can find available plans on the marketplace via `cf marketplace -s redis`.
+You can find available plans on the marketplace using `cf marketplace -s redis`.
 
 <h2 id="remove-the-service">Remove the service</h2>
 

--- a/source/documentation/deploying_services/redis.md
+++ b/source/documentation/deploying_services/redis.md
@@ -167,19 +167,17 @@ Run `cf conduit --help` for more options, and refer to the [Conduit README file]
 
 ### Upgrade Redis service plan
 
-You can upgrade your plan using the `cf update-service` command. Run the following in the command line:
+Our service broker does not currently allow to upgrade Redis services in
+place. In order to upgrade your Redis service, please execute the following
+steps:
 
-```
-cf update-service SERVICE_NAME -p NEW_PLAN_NAME
-```
+1. `cf create-service redis DESIRED_PLAN NEW_REDIS_NAME`
+2. `cf bind-service APP_NAME NEW_REDIS_NAME`
+3. `cf unbind-service APP_NAME OLD_REDIS_NAME`
+4. `cf restage APP_NAME`
+5. `cf delete-service OLD_REDIS_NAME`
 
-where `SERVICE_NAME` is a unique descriptive name for this service instance, and `NEW_PLAN_NAME` is the name of your new plan. For example:
-
-```
-cf update-service my-redis-service -p medium-ha-3.2
-```
-
-The plan upgrade will start immediately and finish within an hour. You can check the status of the upgrade by running `cf services`.
+You can find available plans on the marketplace via `cf marketplace -s redis`.
 
 <h2 id="remove-the-service">Remove the service</h2>
 

--- a/source/documentation/deploying_services/redis.md
+++ b/source/documentation/deploying_services/redis.md
@@ -233,31 +233,13 @@ If you use a high availability service plan, Amazon ElastiCache for Redis provid
 
 If you do not have a high availability service plan, you will lose data during a service instance failure. Before deciding which service plan to use, you should assess your data and what type of plan you need.
 
-### Redis maintenance & backups
+### Redis maintenance
 
 #### Redis maintenance times
 
 Every Redis service has a maintenance window of Sunday 11pm to Monday 1:30am UTC every week. Contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) if you require a different maintenance window.
 
 For more information on maintenance times, refer to the [Amazon ElastiCache maintenance window documentation](https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/VersionManagement.MaintenanceWindow.html).
-
-#### Redis service backup
-
-All service plans are backed up every day.
-
-The data stored within any Redis service instance you create is backed up using the Amazon ElastiCache backup system. Backups are taken every day between 2am and 5am UTC. Data is retained for 7 days, and stored in [Amazon S3](https://aws.amazon.com/s3/).
-
-To restore from the latest backup of your Redis service instance, create a new service instance by running the following code:
-
-```
-cf create-service redis PLAN NEW_SERVICE_NAME -c '{ "restore_from_latest_snapshot_of": "GUID" }'
-```
-
-where `PLAN` is the name of the service plan, `NEW_SERVICE_NAME` is the name of your new service instance, and `GUID` is the UUID of the pre-existing backed-up instance. Get the `GUID` by running `cf service --guid SERVICE_NAME`.
-
-To restore from an older backup, contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk).
-
-For more details about how the backup system works, see the [Amazon's ElastiCache backups documentation](https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/backups-automatic.html).
 
 ### Redis key eviction policy
 

--- a/source/documentation/deploying_services/redis.md.erb
+++ b/source/documentation/deploying_services/redis.md.erb
@@ -167,6 +167,8 @@ Run `cf conduit --help` for more options, and refer to the [Conduit README file]
 
 ### Upgrade Redis service plan
 
+<%= warning_text('Redis upgrades will remove all data stored in the instance.') %>
+
 Our service broker does not currently allow us to upgrade Redis services in
 place. To upgrade your Redis service, perform the following
 steps:


### PR DESCRIPTION

What
----

Update the docs on upgrading Redis instances. Our ElastiCache broker does not currently support `update-service` to upgrade Redis plans. Including step-by-step instructions to work around this (thanks @AP-Hunt).

How to review
-------------

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected. The internal path to the change is `/deploying_services/redis/#upgrade-redis-service-plan`.

Who can review
--------------

Not @schmie 
