### PR TITLE
Fix outdated link

### DIFF
--- a/source/documentation/managing_apps/redirect_all_traffic.md
+++ b/source/documentation/managing_apps/redirect_all_traffic.md
@@ -23,4 +23,4 @@ http {
 Deploy your application to `NEW_DOMAIN_NAME` and then `cf push` a simple static site with that `nginx.conf`
 configuration to the old domain name. You can see a [full working example here](https://github.com/18F/c2-redirect).
 
-You can read more about [nginx customization](https://github.com/cloudfoundry/staticfile-buildpack#advanced-nginx-configuration).
+You can read more about [nginx customization](https://docs.cloudfoundry.org/buildpacks/nginx/index.html).


### PR DESCRIPTION
What
----

"You can read more about nginx customisation" on https://docs.cloud.service.gov.uk/managing_apps.html#redirecting-all-traffic
was  pointing to the StaticBuildpack.

This changes the link to point to nginx buildpack documentation

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. …

Who can review
--------------

not @kr8n3r 
