### PR TITLE
custom domains: remove surplus "need", mention different cloudapps domains

### DIFF
--- a/source/documentation/deploying_services/use_a_custom_domain.erb
+++ b/source/documentation/deploying_services/use_a_custom_domain.erb
@@ -1,6 +1,6 @@
 # Managing custom domains using the cdn-route service
 
-Apps on GOV.UK PaaS are given a default domain of `APP_NAME.london.cloudapps.digital` by default. This is OK to use within your team and for development. However, a live service will need likely need its own custom domain name, such as `my-service.service.gov.uk`. This guide will help you to configure a custom domain.
+Apps on GOV.UK PaaS are given a default domain of `APP_NAME.cloudapps.digital` (or `APP_NAME.london.cloudapps.digital` in the London region) by default. This is OK to use within your team and for development. However, a live service will likely need its own custom domain name, such as `my-service.service.gov.uk`. This guide will help you to configure a custom domain.
 
 ## Register a domain name
 


### PR DESCRIPTION
What
----

Removed the superflous `need` in this sentence.

While I'm at it, notice we only mention `APP_NAME.london.cloudapps.digital`, which would confuse people with apps in ireland, so mention that too.

How to review
-------------

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. …

Who can review
--------------

Anyone that's not me.