### PR TITLE
Adds clarification on sharing URLs for public S3 buckets

### DIFF
--- a/source/documentation/deploying_services/s3.md
+++ b/source/documentation/deploying_services/s3.md
@@ -42,7 +42,7 @@ Run the following in the command line to provision a public AWS S3 bucket:
 ```
 cf create-service aws-s3-bucket default SERVICE_NAME -c '{"public_bucket":true}'
 ```
-where `SERVICE_NAME` is a unique descriptive name for this S3 bucket.
+where `SERVICE_NAME` is a unique descriptive name for this S3 bucket. The configuration option `'{"public_bucket":true}'` makes sure that the S3 bucket is public.
 
 ### Bind an AWS S3 bucket to your app
 
@@ -189,6 +189,11 @@ where:
 
 - `BUCKET_NAME` is the `bucket_name` value in the bucket [environment variables](/deploying_apps.html#system-provided-environment-variables) 
 - `KEY` is the key you gave to the object when uploading that object to the bucket
+
+### Access objects in a private AWS S3 bucket using presigned URLs
+
+You can [generate a presigned URL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html)
+that gives temporary access to an object in a private bucket.
 
 <h2 id="remove-the-service">Remove the service</h2>
 


### PR DESCRIPTION
We do not support signed URLs for private buckets

What
----

This clarifies that we only support signed URLs for public buckets

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. Check that the new content is clear and sufficient

Who can review
--------------

Anyone but me
