### PR TITLE
Correct flag used in CF marketplace command

### DIFF
--- a/source/documentation/deploying_services/elasticsearch.md
+++ b/source/documentation/deploying_services/elasticsearch.md
@@ -11,7 +11,7 @@ Before using Elasticsearch as your primary data store, you should assess if an [
 1. Run the following in the command line to see what plans are available for Elasticsearch:
 
     ```
-    cf marketplace -s elasticsearch
+    cf marketplace -e elasticsearch
     ```
 
     Here is an example of the output you will see:

--- a/source/documentation/deploying_services/mysql.md
+++ b/source/documentation/deploying_services/mysql.md
@@ -13,7 +13,7 @@ To set up a MySQL service:
 1. Run the following code in the command line to see what plans are available for MySQL:
 
     ```
-    cf marketplace -s mysql
+    cf marketplace -e mysql
     ```
 
     Here is an example of the output you will see (the exact plans will vary):

--- a/source/documentation/deploying_services/redis.md
+++ b/source/documentation/deploying_services/redis.md
@@ -13,7 +13,7 @@ To set up a Redis service:
 1. Run the following in the command line to see what service plans are available for Redis:
 
     ```
-    cf marketplace -s redis
+    cf marketplace -e redis
     ```
 
     Here is an example of the output you will see (the exact service plans will vary):


### PR DESCRIPTION
What
----

The `-s` flag was correct in CF CLI v6, but changed to `-e` in
CF CLI v7.
