### PR TITLE
[#180028025] Clarify that unencrypted database plans are not backed up

### DIFF
--- a/source/documentation/deploying_services/mysql.md
+++ b/source/documentation/deploying_services/mysql.md
@@ -391,7 +391,7 @@ You can only migrate your service if the new plan has the [same encryption type]
 
 #### MySQL service backup
 
-The data stored within any MySQL service you create is backed up using the standard Amazon RDS backup system if you are using a paid plan. Your data is not backed up if you are using the free plan.
+The data stored within any MySQL service you create is backed up using the standard Amazon RDS backup system if you are using a paid plan. Your data is not backed up if you are using the unencrypted plans.
 
 Backups are taken nightly at some time between 22:00 and 06:00 UTC. Data is retained for 7 days.
 

--- a/source/documentation/deploying_services/postgresql.md.erb
+++ b/source/documentation/deploying_services/postgresql.md.erb
@@ -620,7 +620,7 @@ You can only migrate your service if the new plan has the [same encryption type]
 
 #### PostgreSQL service backup
 
-The data stored within any PostgreSQL service you create is backed up using the standard Amazon RDS backup system if you are using a paid plan. Your data is not backed up if you are using the free plan.
+The data stored within any PostgreSQL service you create is backed up using the standard Amazon RDS backup system if you are using a paid plan. Your data is not backed up if you are using the unencrypted plans.
 
 Backups are taken nightly at some time between 22:00 and 06:00 UTC. Data is retained for 7 days.
 


### PR DESCRIPTION
What
----

Previously, the sentence suggested this was true only for free
plans. However, this isn't quite true, because we don't begin
backing up those plans once a tenant begins paying for it.

To explain: free plans are only free to trial organisations.
Once an organisation exits the trial period, they pay for
everything they use.

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. …

Who can review
--------------

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.
