### PR TITLE
opensearch restore: `restore_from_latest_backup_of` expects a guid

### DIFF
--- a/source/documentation/deploying_services/opensearch.md
+++ b/source/documentation/deploying_services/opensearch.md
@@ -183,19 +183,19 @@ GOV.UK PaaS will remove support for Elasticsearch in the first quarter of 2022. 
 You can migrate from Elasticsearch to OpenSearch by creating an OpenSearch backing service from a backup of an Elasticsearch service.
 
 ```
-cf create-service opensearch OPENSEARCH_PLAN OPENSEARCH_SERVICE_NAME -c '{"restore_from_latest_backup_of": "ELASTICSEARCH_SERVICE_NAME"}'
+cf create-service opensearch OPENSEARCH_PLAN OPENSEARCH_SERVICE_NAME -c '{"restore_from_latest_backup_of": "ELASTICSEARCH_SERVICE_GUID"}'
 ```
 
 where:
 
 - `OPENSEARCH_PLAN` is the name of the OpenSearch service plan you want
 - `OPENSEARCH_SERVICE_NAME` is a unique descriptive name for the new service instance
-- `ELASTICSEARCH_SERVICE_NAME` is the name of an Elasticsearch service instance from which the latest backup will be picked
+- `ELASTICSEARCH_SERVICE_GUID` is the `GUID` (Global Unique Identifier) of an Elasticsearch service instance from which the latest backup will be picked
 
 For example:
 
 ```
-cf create-service opensearch small-ha-1 my-new-opensearch -c '{"restore_from_latest_backup_of": "my-old-elasticsearch"}'
+cf create-service opensearch small-ha-1 my-new-opensearch -c '{"restore_from_latest_backup_of": "32938730-e603-44d6-810e-b4f12d7d109e"}'
 ```
 
 When you create an OpenSearch backing service in this way, existing data will be available in the OpenSearch service. However new data added to the Elasticsearch service will not be replicated to the OpenSearch service, and vice versa.


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180810438

What
----

Turns out you don't use the service name for restoring OS instances, you use the GUID. Really, we should probably flesh this out to be more like (a clone of?) the instructions we use for postgres, where we include details of how to discover a service's guid - but right now I just want to get these words switched to prevent this from being wrong.

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. …

Who can review
--------------

Not @risicle 