### PR TITLE
Adds alternative option for getting instance information

### DIFF
--- a/source/documentation/deploying_services/use_a_custom_domain.erb
+++ b/source/documentation/deploying_services/use_a_custom_domain.erb
@@ -416,6 +416,36 @@ Server error, status code: 409, error code: 60016, message: An operation for ser
 
 This happens because you cannot do anything to a service instance while it's in a pending state. A CDN service instance stays pending until it detects the CNAME or ALIAS record. If this causes a problem for you, [contact support](https://www.cloud.service.gov.uk/support) to ask us to manually delete the pending instance.
 
+#### View the service configuration
+The `message` field may appear blank following operations such as changing the forwarded headers. In that case, you can get information about the configured domains using:
+
+```
+cf curl "/v3/service_instances/$(cf service SERVICE_INSTANCE --guid)/parameters"
+```
+
+where `SERVICE_INSTANCE` is the name of one of your existing cdn-route service instances.
+
+Example output:
+
+```
+{
+   "cache_ttl": 0,
+   "cloudfront_domain": "d3j6yjt78pkdqf.cloudfront.net",
+   "dns_records": [
+      {
+         "validating_domain_name": "www.example.com",
+         "challenge_dns_record": "_83878ed284b0b5fcaa3e99a618432ac8.www.example.com",
+         "challenges_dns_record_type": "CNAME",
+         "challenges_dns_record_value": "_5c7e8297b9691c59197e4e10b5bf0a98.tfmgdnztqk.acm-validations.aws",
+         "status": "SUCCESS"
+      }
+   ],
+   "forward_cookies": true,
+   "forwarded_headers": [
+      "Host"
+   ]
+}
+```
 
 ## How custom domains work
 


### PR DESCRIPTION
What
----

Updates docs to show how to use `cf service SERVICE_INSTANCE`

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. …

Who can review
--------------
Anyone
@AP-Hunt  and @cmcnallygds please 
