### PR TITLE
Correctly install CF in GitHub Actions documentation

### DIFF
--- a/source/documentation/using_ci/github_actions.md
+++ b/source/documentation/using_ci/github_actions.md
@@ -42,9 +42,8 @@ jobs:
 
       - name: Install the CF CLI
         run: |
-          wget -O cf.tar.gz "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=7.4.0&source=github-rel"
-          tar xzf cf.tar.gz
-          sudo mv cf /usr/local/bin/cf
+          wget -q -O cf.tar.gz "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=7.4.0&source=github-rel"
+          sudo tar xzf cf.tar.gz --wildcards --directory /usr/local/bin/ "cf*"
 
       - name: Authenticate
         env:


### PR DESCRIPTION
What
----

We weren't installing CloudFoundry CLI quite right in our GitHub Actions
documentation. It wasn't copying all the right files, because `cf` was a
symlink to `./cf7` and we weren't copying that.

How to review
-------------

Take a look [at the result of the last run on my test branch](https://github.com/alphagov/paas-tech-docs/runs/4969504850?check_suite_focus=true). I've deleted the branch (d'oh), but the logs show what commands were being run. You can see they work and match what's in this PR.
