### PR TITLE
logit/logstash filters: add paragraph on severity levels to expect

### DIFF
--- a/source/documentation/monitoring_apps/logs.md
+++ b/source/documentation/monitoring_apps/logs.md
@@ -135,6 +135,8 @@ You must set up [Logstash](https://www.elastic.co/products/logstash) to process 
 1. Select __Apply__ once the code is valid. If this is not possible, check you have copied the code correctly or contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) .
 1. Go back to the Logit dashboard once the following message appears: “Filters have been applied to logstash, logstash will be restarted, this may take up to 2 minutes”.
 
+This configuration will result in application logs with two different levels of severity. Lines output from the app's `stdout` will have a `syslog_severity` of `informational` and lines output from the app's `stderr` will have a `syslog_severity` of `error`. For finer-grained severity levels, the logstash filter would need to be customized to extract this information from line contents.
+
 ### Configure app
 
 1. Select __Settings__ for the stack you want to use.


### PR DESCRIPTION
What
----
Following https://www.pivotaltracker.com/story/show/181201741

Added paragraph clarifying what severity level information to expect from the example logstash configuration we provide. Otherwise people may be confused when they don't get their full gamut of log levels represented in their ELK stack.

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. …

Who can review
--------------

Anyone but @risicle though hopefully someone with a content eye.