### PR TITLE
Switch git protocol for linkchecker repo to https

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git+git://github.com/linkchecker/linkchecker.git@f395c74aac13417f5676c53a91da79e6695bb8c1
+git+https://github.com/linkchecker/linkchecker.git@f395c74aac13417f5676c53a91da79e6695bb8c1
 requests>=2.15.0


### PR DESCRIPTION
What
----

`pip install -r requirements.txt` is encountering a fatal error when attempting to clone the linkchecker repo using the unencrypted git protocol.

This is because this functionality has been deprecated ([link](https://github.blog/2021-09-01-improving-git-protocol-security-github/)).

How to review
-------------

- Make sure the "Run pip install --user -r requirements.txt" step in the GitHub Actions "Run tests" job is passing.
- Think of any reason why we should use SSH instead of HTTPS, here - given that is was unauthenticated and unencrypted before, I think this is unnessecary.

Who can review
--------------

not @schmie
