### PR TITLE
mysql paas/paas backup: note `mysqldump` flags that might be needed on newer versions

### DIFF
--- a/source/documentation/deploying_services/mysql.md
+++ b/source/documentation/deploying_services/mysql.md
@@ -195,6 +195,8 @@ To move data between two PaaS-hosted MySQL databases:
     - `DATA_FILE_NAME` is the SQL data file name created by the `mysqldump` command
     - `DATABASE_NAME` is the name of the source database (you should get this from the [`VCAP_SERVICES` environment variable](/deploying_services/mysql/#bind-a-mysql-service-to-your-app))
 
+    Depending on the version of your local `mysqldump` tool, you may need to add the flags `--no-tablespaces` and/or `--column-statistics=0` to exclude metadata that cannot be accessed on GOV.UK PaaS from the data dump.
+
 2. Run the following command to import the data file into the target database:
 
      ```


### PR DESCRIPTION
What
----

See https://govuk.zendesk.com/agent/tickets/5000660

Figuring out the exact combinations of server/client versions that need these and communicating that here would be too much. This at least points people in the right direction.

![Screenshot_20220621_170733](https://user-images.githubusercontent.com/807447/174846545-cc0d638c-4d24-4664-a0a9-78c42fa6396c.png)

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. …

Who can review
--------------

Not @risicle 