### PR TITLE
Update commonmarker  from 0.23.5 to 0.23.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    commonmarker (0.23.5)
+    commonmarker (0.23.6)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)


### PR DESCRIPTION
What
----

Update commonmarker from 0.23.5 to 0.23.6 to address [CVE](https://github.com/alphagov/paas-tech-docs/security/dependabot/14)
