### PR TITLE
add pointers to the migration guide to home page and guidance section

### DIFF
--- a/source/documentation/guidance/migration.md
+++ b/source/documentation/guidance/migration.md
@@ -1,0 +1,5 @@
+## Migrating from GOV.UK PaaS
+
+GOV.UK PaaS is a live service. However, we are decommissioning the service, with a planned retirement date of 23 December 2023. You can [read our blog post announcement](https://gds.blog.gov.uk/2022/07/12/why-weve-decided-to-decommission-gov-uk-paas-platform-as-a-service/).
+
+To understand how you can prepare to migrate your services and how the GOV.UK PaaS team can help, read our [migration guidance](https://cloud.service.gov.uk/migration-guidance)

--- a/source/documentation/guidance/pentest.md
+++ b/source/documentation/guidance/pentest.md
@@ -1,4 +1,3 @@
-# Guidance
 
 ## Penetration testing
 

--- a/source/documentation/index.md
+++ b/source/documentation/index.md
@@ -1,9 +1,11 @@
 # GOV.UK Platform as a Service
 
-GOV.UK Platform as a Service (PaaS) is a cloud-hosting platform built by the Government Digital Service (GDS). GOV.UK PaaS manages the deployment of your apps, services and background tasks so you don’t need to hire people with specialist cloud skills.
+GOV.UK Platform as a Service (PaaS) is a cloud hosting platform built by the Government Digital Service (GDS). GOV.UK PaaS manages the deployment of your apps, services, and background tasks so you do not need to hire people with specialist cloud skills.
 
-The GOV.UK PaaS is hosted in two regions, London and Ireland.
+GOV.UK PaaS is hosted in two regions: London and Ireland.
 
-GOV.UK PaaS is a live service, however it is being decommissioned by December 2023. You can [read our blog post announcement](https://gds.blog.gov.uk/2022/07/12/why-weve-decided-to-decommission-gov-uk-paas-platform-as-a-service/).
+GOV.UK PaaS uses the open source [Cloud Foundry](https://www.cloudfoundry.org/) project and runs on Amazon Web Services (AWS).
 
-GOV.UK PaaS uses the open source [Cloud Foundry](https://www.cloudfoundry.org/) project, and runs on Amazon Web Services.
+GOV.UK PaaS is a live service. However, we are decommissioning the service, with a planned retirement date of 23 December 2023. You can [read our blog post announcement](https://gds.blog.gov.uk/2022/07/12/why-weve-decided-to-decommission-gov-uk-paas-platform-as-a-service/).
+
+To understand how you can prepare to migrate your services and how the GOV.UK PaaS team can help, read our [migration guidance](https://cloud.service.gov.uk/migration-guidance).

--- a/source/guidance.html.md.erb
+++ b/source/guidance.html.md.erb
@@ -3,6 +3,9 @@ title: "Guidance"
 weight: 120
 ---
 
+# Guidance
+
+<%= partial 'documentation/guidance/migration' %>
 <%= partial 'documentation/guidance/pentest' %>
 <%= partial 'documentation/guidance/php-database' %>
 <%= partial 'documentation/guidance/isolation-segments' %>


### PR DESCRIPTION
What
----

Add pointers to migration guidance to take user to the actual guidance that will reside on the product pages at https://cloud.service.gov.uk/migration-guidance 

> this is blocked by https://www.pivotaltracker.com/n/projects/1275640/stories/183626154 
which is the story to deploy the actual guidance to the product pages, do not merge this pr until this story is played. 

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.


Who can review
--------------

anyone but @pauldougan


