### PR TITLE
Update retention snapshot period to match reality

### DIFF
--- a/source/documentation/deploying_services/mysql.md
+++ b/source/documentation/deploying_services/mysql.md
@@ -395,13 +395,13 @@ You can only migrate your service if the new plan has the [same encryption type]
 
 The data stored within any MySQL service you create is backed up using the standard Amazon RDS backup system if you are using a paid plan. Your data is not backed up if you are using the unencrypted plans.
 
-Backups are taken nightly at some time between 22:00 and 06:00 UTC. Data is retained for 7 days.
+Backups are taken nightly at some time between 22:00 and 06:00 UTC. Data is retained for 35 days.
 
 There are two ways you can restore data to an earlier state:
 
 1. You can restore to the latest snapshot. Refer to [Restoring a MySQL service snapshot](/deploying_services/mysql/#restoring-a-mysql-service-snapshot) for details.
 
-1. You can restore to any point from 5 minutes to 7 days ago, with a resolution of one second. Refer to [Restoring a MySQL service from a point in time](/deploying_services/mysql/#restoring-a-mysql-service-from-a-point-in-time) for details.
+1. You can restore to any point from 5 minutes to 35 days ago, with a resolution of one second. Refer to [Restoring a MySQL service from a point in time](/deploying_services/mysql/#restoring-a-mysql-service-from-a-point-in-time) for details.
 
 Note that data restore will not be available in the event of an RDS outage that affects the entire Amazon availability zone.
 
@@ -529,7 +529,7 @@ To restore from a point in time:
   * You cannot restore from a service instance that has been deleted
   * You must use the same service plan for the copy as for the original service
   instance
-  * You cannot restore to a point in time prior to the oldest snapshot (7 days ago)
+  * You cannot restore to a point in time prior to the oldest snapshot (35 days ago)
   * You must create the new service instance in the same organisation and space
   as the original. This is to prevent unauthorised access to data between
   spaces. If you need to copy data to a different organisation and/or space,

--- a/source/documentation/deploying_services/postgresql.md.erb
+++ b/source/documentation/deploying_services/postgresql.md.erb
@@ -622,13 +622,13 @@ You can only migrate your service if the new plan has the [same encryption type]
 
 The data stored within any PostgreSQL service you create is backed up using the standard Amazon RDS backup system if you are using a paid plan. Your data is not backed up if you are using the unencrypted plans.
 
-Backups are taken nightly at some time between 22:00 and 06:00 UTC. Data is retained for 7 days.
+Backups are taken nightly at some time between 22:00 and 06:00 UTC. Data is retained for 35 days.
 
 There are two ways you can restore data to an earlier state:
 
 1. You can restore to the latest snapshot. Refer to [Restoring a PostgreSQL service snapshot](/deploying_services/postgresql/#restoring-a-postgresql-service-snapshot) for details.
 
-1. You can restore to any point from 5 minutes to 7 days ago, with a resolution of one second. Refer to [Restoring a PostgreSQL service from a point in time](/deploying_services/postgresql/#restoring-a-postgresql-service-from-a-point-in-time) for details.
+1. You can restore to any point from 5 minutes to 35 days ago, with a resolution of one second. Refer to [Restoring a PostgreSQL service from a point in time](/deploying_services/postgresql/#restoring-a-postgresql-service-from-a-point-in-time) for details.
 
 Note that data restore will not be available in the event of an RDS outage that affects the entire Amazon availability zone.
 
@@ -756,7 +756,7 @@ To restore from a point in time:
   * You cannot restore from a service instance that has been deleted
   * You must use the same service plan for the copy as for the original service
   instance
-  * You cannot restore to a point in time prior to the oldest snapshot (7 days ago)
+  * You cannot restore to a point in time prior to the oldest snapshot (35 days ago)
   * You must create the new service instance in the same organisation and space
   as the original. This is to prevent unauthorised access to data between
   spaces. If you need to copy data to a different organisation and/or space,


### PR DESCRIPTION
What
----

Our snapshot retention period is 35 days. We thought we had changed it to 7, but as it turns out we had not.

Context from AP-hunt digging into things:

> 1. We set the final snapshot retention period to 35 days in March 2018 and have never revisited it
> 2. The automated snapshot retention period is configured at the plan level, because ..
> 3. In September 2016 we marked the tests for user configurability of  backup retention as Pending in the test suite, and have never revisited it. At the time, the relevant code looked like
>     
>         if provisionParameters.BackupRetentionPeriod > 0 {
>             dbInstanceDetails.BackupRetentionPeriod = provisionParameters.BackupRetentionPeriod
>         }
>     
> 4. In September 2018 we did some refactoring and replaced the above with` BackupRetentionPeriod:      servicePlan.RDSProperties.BackupRetentionPeriod`,. It wasn’t caught because the tests are marked pending.

How to review
-------------

Check that the correct  numbers have been changed (did I miss any?)

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. …

Who can review
--------------

Anyone
