### PR TITLE
Update to cf v8

### DIFF
--- a/source/documentation/deploying_apps/index.erb
+++ b/source/documentation/deploying_apps/index.erb
@@ -155,7 +155,7 @@ You must create a [network policy](https://cli.cloudfoundry.org/en-US/cf/add-net
 1. Run the following in the command line to create the network policy:
 
 ```
-cf add-network-policy PUBLIC_APPNAME --destination-app PRIVATE_APPNAME --protocol tcp --port 8080
+cf add-network-policy PUBLIC_APPNAME PRIVATE_APPNAME --protocol tcp --port 8080
 ```
 
 <%= warning_text('If you are using Cloud Foundry CLI version 6 and the blue-green deploy plugin, you must recreate the network policy after each deployment') %>

--- a/source/documentation/deploying_apps/stopping_and_deleting_apps.md.erb
+++ b/source/documentation/deploying_apps/stopping_and_deleting_apps.md.erb
@@ -34,7 +34,7 @@ cf delete APPNAME
 
 ### Deleting app routes
 
-Run the following to delete an app and that app’s [routes](https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#routes) at the same time:
+Run the following to delete an app and that app’s [routes](https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#routes) at the same time, as long as those routes are not also mappped to other apps:
 
 ```
 cf delete -r APPNAME

--- a/source/documentation/deploying_services/configure_cdn.md
+++ b/source/documentation/deploying_services/configure_cdn.md
@@ -30,7 +30,7 @@ There are many different CDNs available. Contact us at [gov-uk-paas-support@digi
 2. Create a domain in your organisation (replace `ORGNAME` with your org name, and replace `example.com` with your domain):
 
     ```bash
-    cf create-domain ORGNAME example.com
+    cf create-private-domain ORGNAME example.com
     ```
 
 3. Map the subdomain route to your application:

--- a/source/documentation/deploying_services/redis.md.erb
+++ b/source/documentation/deploying_services/redis.md.erb
@@ -179,7 +179,7 @@ steps:
 4. `cf restage APP_NAME`
 5. `cf delete-service OLD_REDIS_NAME`
 
-You can find available plans on the marketplace using `cf marketplace -s redis`.
+You can find available plans on the marketplace using `cf marketplace -e redis`.
 
 <h2 id="remove-the-service">Remove the service</h2>
 

--- a/source/documentation/deploying_services/use_a_custom_domain.erb
+++ b/source/documentation/deploying_services/use_a_custom_domain.erb
@@ -37,7 +37,7 @@ Before you start setting up your service, you must be able to set TXT and CNAME 
 1. Create the required domain(s) in your organisation:
 
     ```
-    cf create-domain ORG_NAME APEX_DOMAIN_NAME
+    cf create-private-domain ORG_NAME APEX_DOMAIN_NAME
     ```
 
     where `APEX_DOMAIN_NAME` is the name of the apex domain, for example `example.service.gov.uk`
@@ -298,7 +298,7 @@ Your app can now receive requests through the subdomain.
 1. Remove the custom domain from Cloud Foundry's routing database:
 
     ```
-    cf delete-domain DOMAIN_NAME
+    cf delete-private-domain DOMAIN_NAME
     ```
     This also deletes the custom domain from every app using that domain.
 

--- a/source/documentation/deploying_services/use_a_custom_domain.erb
+++ b/source/documentation/deploying_services/use_a_custom_domain.erb
@@ -283,7 +283,7 @@ Your app can now receive requests through the subdomain.
 1. Your org manager should check if any apps are using a custom domain before removing that domain:
 
     ```
-    cf routes --orglevel | grep -we DOMAIN_NAME -e^space
+    cf routes --org-level | grep -we DOMAIN_NAME -e^space
     ```
 
     Example output:

--- a/source/documentation/managing_apps/quotas.md
+++ b/source/documentation/managing_apps/quotas.md
@@ -46,7 +46,7 @@ isolation segments:
 
 To see the details of that quota, run:
 
-``cf quota QUOTA``
+``cf org-quota QUOTA``
 
 where QUOTA is the name of the quota that GOV.UK PaaS has assigned to your org.
 
@@ -62,7 +62,7 @@ Reserved Route Ports   0
 
 To see all quotas available on the GOV.UK PaaS, run the command:
 
-``cf quotas``
+``cf org-quotas``
 
 ### Quota limits
 

--- a/source/documentation/monitoring_apps/metrics.md
+++ b/source/documentation/monitoring_apps/metrics.md
@@ -34,14 +34,10 @@ We recommend this GOV.UK PaaS account:
 1. [Push the PaaS Prometheus exporter app](/deploying_apps.html#deploying-public-apps) to Cloud Foundry without starting the app:
 
 	```
-	cf push --no-start prometheus-exporter --hostname prometheus-exporter-ORGNAME
+	cf push --no-start prometheus-exporter --var orgname=ORGNAME
 	```
 
-	where `ORGNAME` is the name of your org. For example:
-
-	```
-	cf push --no-start prometheus-exporter --hostname prometheus-exporter-exampleorg
-	```
+	where `ORGNAME` is the name of your org. Note this replaces the `--hostname` flag from cf CLI v6, which was removed in cf CLI v7.
 
 	Running this command deploys the PaaS Prometheus exporter app to `https://prometheus-exporter-exampleorg.cloudapps.digital` without starting the app.
 

--- a/source/documentation/monitoring_apps/metrics.md
+++ b/source/documentation/monitoring_apps/metrics.md
@@ -34,10 +34,10 @@ We recommend this GOV.UK PaaS account:
 1. [Push the PaaS Prometheus exporter app](/deploying_apps.html#deploying-public-apps) to Cloud Foundry without starting the app:
 
 	```
-	cf push --no-start prometheus-exporter --var orgname=ORGNAME
+	cf push --no-start prometheus-exporter-ORGNAME
 	```
 
-	where `ORGNAME` is the name of your org. Note this replaces the `--hostname` flag from cf CLI v6, which was removed in cf CLI v7.
+	where `ORGNAME` is the name of your org. Note this is an alternative to using the `--hostname` flag from cf CLI v6, which was removed in cf CLI v7.
 
 	Running this command deploys the PaaS Prometheus exporter app to `https://prometheus-exporter-exampleorg.cloudapps.digital` without starting the app.
 


### PR DESCRIPTION
What
----

We're using cf cli v8 so the examples in our docs should use the same version. 

I've gone through all the examples in the docs to check if any of the command differences from the [cf cli v7](https://docs.cloudfoundry.org/cf-cli/v7.html#differences) and [cf cli v8](https://docs.cloudfoundry.org/cf-cli/v8.html#differences) were relevant.

The removal of the `--hostname` flag also required a change in the [paas-prometheus-exporter](https://github.com/alphagov/paas-prometheus-exporter/pull/47)

How to review
-------------
1. do the changes make sense? in particular the `--hostname` flag one

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. …

Who can review
--------------

Anyone
