### PR TITLE
Update nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
     mini_portile2 (2.8.0)
     minitest (5.15.0)
     multi_json (1.15.0)
-    nokogiri (1.13.9)
+    nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     openapi3_parser (0.9.2)
@@ -145,7 +145,7 @@ GEM
     parallel (1.22.1)
     parslet (2.0.0)
     public_suffix (4.0.7)
-    racc (1.6.0)
+    racc (1.6.1)
     rack (2.2.3.1)
     rack-livereload (0.3.17)
       rack


### PR DESCRIPTION
resolve CVE
replaces https://github.com/alphagov/paas-tech-docs/pull/470
