### PR TITLE
service maintenance windows: make consistent across redis/mysql/postgresql

### DIFF
--- a/source/documentation/deploying_services/mysql.md
+++ b/source/documentation/deploying_services/mysql.md
@@ -368,7 +368,19 @@ For services which have a large volume of database reads and writes, GOV.UK PaaS
 
 Each MySQL service you create will have a randomly-assigned weekly 30 minute maintenance window, during which there may be brief downtime. Select a high availability (`HA`) plan to minimise this downtime. Minor version upgrades (for example from 5.7.1 to 5.7.2) are applied during this maintenance window.
 
-Contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) to find out the default time of your maintenance window. Window start times will vary from 22:00 to 06:00 UTC.
+You can retrieve the day and time of this maintenance window with the Cloud Foundry CLI (version 8 and above) by running:
+
+```
+cf service --params SERVICE_NAME
+```
+
+```json
+{
+  ...
+  "preferred_maintenance_window": "sun:23:00-mon:01:30"
+  ...
+}
+```
 
 You can set your own maintenance window by running `cf update-service` in the command line and setting the `preferred_maintenance_window` custom parameter:
 

--- a/source/documentation/deploying_services/postgresql.md.erb
+++ b/source/documentation/deploying_services/postgresql.md.erb
@@ -605,7 +605,19 @@ GOV.UK PaaS does not currently support read replicas, but if you think you would
 
 Each PostgreSQL service you create will have a randomly-assigned weekly 30 minute maintenance window, during which there may be brief downtime. Select a high availability (`HA`) plan to minimise this downtime. Minor version upgrades (for example from 12.13 to 12.15) are applied during this maintenance window.
 
-Contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) to find out the default time of your maintenance window. Window start times will vary from 22:00 to 06:00 UTC.
+You can retrieve the day and time of this maintenance window with the Cloud Foundry CLI (version 8 and above) by running:
+
+```
+cf service --params SERVICE_NAME
+```
+
+```json
+{
+  ...
+  "preferred_maintenance_window": "sun:23:00-mon:01:30"
+  ...
+}
+```
 
 You can set your own maintenance window by running `cf update-service` in the command line and setting the `preferred_maintenance_window` custom parameter:
 

--- a/source/documentation/deploying_services/redis.md.erb
+++ b/source/documentation/deploying_services/redis.md.erb
@@ -248,13 +248,21 @@ cf service --params SERVICE_NAME
 ```json
 {
   "daily_backup_window": "02:00-05:00",
-  "maintenance_window": "sun:23:00-mon:01:30"
+  "preferred_maintenance_window": "sun:23:00-mon:01:30"
 }
 ```
 
+You can set your own maintenance window by running `cf update-service` in the command line and setting the `preferred_maintenance_window` custom parameter:
 
+```
+cf update-service SERVICE_NAME -c '{"preferred_maintenance_window": "START_DAY:START_TIME-END_DAY:END_TIME"}'
+```
 
-Contact us at [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) if you require a different maintenance window.
+where `SERVICE_NAME` is a unique, descriptive name for this service instance, for example:
+
+```
+cf update-service my-redis-service -c '{"preferred_maintenance_window": "Tue:04:00-Tue:04:30"}'
+```
 
 For more information on maintenance times, refer to the [Amazon ElastiCache maintenance window documentation](https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/VersionManagement.MaintenanceWindow.html).
 


### PR DESCRIPTION
What
----

See https://www.pivotaltracker.com/story/show/184072404

These services can now all have their maintenance window get & set and should be documented as such. Fill in missing sections using sections from other services' pages.

Here I've used a "truncated" json notation with ellipses `...` for the output listings to highlight the important value and also not list N other irrelevant returned parameters that we'd otherwise need to remember to update any time we changed the set of returned parameters. Hope that's ok.

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. …
