### PR TITLE
route_services: add caveat about using ip-restriction service with CDNs

### DIFF
--- a/source/documentation/deploying_services/route_services.md
+++ b/source/documentation/deploying_services/route_services.md
@@ -139,6 +139,15 @@ This example app uses the `X-Forwarded-For` header added by the GOV.UK PaaS rout
 Using an IP address to authenticate HTTP requests is not sufficient as a standalone authentication mechanism.
 You should use other authentication and authorization methods in your apps.
 
+Note: the example nginx configuration used in this app will not work out of the box
+when used with requests routed through a CDN. This includes requests routed through our
+own AWS CloudFront-based [cdn-route services](/deploying_services/use_a_custom_domain/). For these to work, you need to add [`set_real_ip_from`](https://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from)
+entries to `nginx.conf` for all IP ranges the CDN may forward
+traffic from. For CloudFront, this includes potentially hundreds of address ranges
+which are [published by AWS](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/LocationsOfEdgeServers.html)
+through a JSON file. These ranges are not completely static and you will need to
+update them occasionally.
+
 #### Using the `X-Forwarded-For` header
 
 The `X-Forwarded-For` header is useful for working out the source IP address of the originating HTTP request, and can be used for authentication, or analytics.


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/180890489

Thinking about this more, if we were in other circumstances the thing to do here would probably be to just add a script to the `paas-ip-authentication-route-service` repo that would scrape and insert/update the appropriate IPs for them.

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. …
