### PR TITLE
pr-tests workflow: upgrade to ubuntu-22.04 base

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   test:
     name: Run tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
What
----

Upgrade this GitHub workflow to ~20.04~ 22.04, ubuntu 18.04 being now deprecated and this preventing the workflow from running in e.g. https://github.com/alphagov/paas-tech-docs/pull/476

How to review
-------------

:eyes: 