### PR TITLE
Enforce a "-" separator in dependabot branch names

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+version: 2
+updates:
+- package-ecosystem: "npm"
+  directory: "/"
+  schedule:
+    interval: "monthly"
+  pull-request-branch-name:
+    separator: "-"


### PR DESCRIPTION
What
----

Our CI system doesn't like the "/" separator in branch names. Forcing the use of a dash should fix it.

How to review
-------------

Is the dependabot config right? Is the frequency OK?