### PR TITLE
Add a note about not relying on `cf logs`

### DIFF
--- a/source/documentation/monitoring_apps/logs.md
+++ b/source/documentation/monitoring_apps/logs.md
@@ -22,6 +22,12 @@ You can also run `cf events` to see all recent app events, such as when an app s
 cf events APP_NAME
 ```
 
+There are a number of factors that can [affect log delivery and retention
+through `cf logs`](https://github.com/cloudfoundry/log-cache-release#reliability). You should not rely solely on `cf logs` for your production
+systems. You should [configure a syslog
+drain](#set-up-the-logit-log-management-service) to persist the logs in your
+own log storage system.
+
 ## Set up the Logit log management service
 
 By default, Cloud Foundry streams a limited amount of logs to your terminal for a defined time. You can use a commercial log management service to keep more logging information for longer. This section describes how to set up the [Logit log management service](https://logit.io/).


### PR DESCRIPTION
What
----

There are lots of different ways `cf logs` can give you a suboptimal experience. You should use a syslog drain for stuff you really care about.

How to review
-------------

1. Accurate copy?
2. Correct tone?

Who can review
--------------

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.
