### PR TITLE
redis: document `test_failover` feature

### DIFF
--- a/source/documentation/deploying_services/mysql.md
+++ b/source/documentation/deploying_services/mysql.md
@@ -284,7 +284,7 @@ Run the following to reboot your highly available service and force a failover:
 cf update-service SERVICE_NAME -c '{"reboot": true, "force_failover": true}'
 ```
 
-When you force a failover, your MySQL database IP address will change. The database's hostname will not change. You must configure your app to close all database connections to the previous IP address after forcing a failover.
+When you force a failover, your MySQL database IP address will change. The database's hostname will not change. You must configure your app to close all database connections to the previous IP address when a failover happens.
 
 <h2 id="remove-the-service">Remove the service</h2>
 

--- a/source/documentation/deploying_services/postgresql.md.erb
+++ b/source/documentation/deploying_services/postgresql.md.erb
@@ -346,7 +346,7 @@ Run the following code to reboot your highly available service and force a failo
 cf update-service SERVICE_NAME -c '{"reboot": true, "force_failover": true}'
 ```
 
-When you force a failover, your PostgreSQL database IP address will change. The database's hostname will not change. You must configure your app to close all database connections to the previous IP address after forcing a failover.
+When you force a failover, your PostgreSQL database IP address will change. The database's hostname will not change. You must configure your app to close all database connections to the previous IP address when a failover happens.
 
 ### Add or remove extensions for a PostgreSQL service instance
 

--- a/source/documentation/deploying_services/redis.md.erb
+++ b/source/documentation/deploying_services/redis.md.erb
@@ -266,6 +266,18 @@ cf update-service my-redis-service -c '{"preferred_maintenance_window": "Tue:04:
 
 For more information on maintenance times, refer to the [Amazon ElastiCache maintenance window documentation](https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/VersionManagement.MaintenanceWindow.html).
 
+#### Force a failover
+
+If you have a [highly available service instance](/deploying_services/redis/#high-availability-plans-redis), you can force a [failover](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/AutoFailover.html) for that service instance. You can use this to test how your app behaves when a failover happens.
+
+Run the following to force a failover of your highly-available service:
+
+```
+cf update-service SERVICE_NAME -c '{"test_failover": true}'
+```
+
+When you force a failover, your Redis service's IP address will change. The service's hostname will not change. You must configure your app to close all Redis connections to the previous IP address when a failover happens.
+
 ### Redis key eviction policy
 
 The eviction policy is the behaviour Redis follows when you reach your service plan's maximum memory limit. The eviction policy can take the following values:


### PR DESCRIPTION
What
----

Related to https://www.pivotaltracker.com/story/show/183510470, we need to document this if we want to point tenants towards it in communication.

Largely cribbed from mysql section.

Incidentally, update mysql and postgresql section's final sentences, which previously implied tenants just had to make sure it worked when manually triggered, which is kinda missing the point.

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
1. …
