### PR TITLE
Switch nginx config template to use formatting used by nginx_buildpack

### DIFF
--- a/redirect/nginx.conf
+++ b/redirect/nginx.conf
@@ -1,27 +1,24 @@
-# This configuration is based from the CloudFoundry static buildpack's default, which you can view here:
-# https://github.com/cloudfoundry/staticfile-buildpack/blob/bd7a288e11b27f1c5095d62bcd09780a14c5151e/conf/nginx.conf
 worker_processes 1;
 daemon off;
 
-error_log <%= ENV["APP_ROOT"] %>/nginx/logs/error.log;
+error_log /dev/stderr;
 events { worker_connections 1024; }
 
 http {
   charset utf-8;
   log_format cloudfoundry '$http_x_forwarded_for - $http_referer - [$time_local] "$request" $status $body_bytes_sent';
-  access_log <%= ENV["APP_ROOT"] %>/nginx/logs/access.log cloudfoundry;
+  access_log /dev/stdout cloudfoundry;
 
   keepalive_timeout 30;
-  port_in_redirect off; # Ensure that redirects don't include the internal container PORT - <%= ENV["PORT"] %>
+  port_in_redirect off;
   server_tokens off;
 
   server {
-    listen <%= ENV["PORT"] %>;
+    listen {{ port }};
     server_name localhost;
 
     location / {
-      root <%= ENV["APP_ROOT"] %>/public;
-      return 301 https://<%= ENV["REDIRECT_DOMAIN"] %>$request_uri;
+      return 301 https://{{ env "REDIRECT_DOMAIN" }}$request_uri;
     }
 
     location /security.txt {


### PR DESCRIPTION
What
----

Changing the nginx template to use the format used by the nginx_buildpack.

Why
----

The staticfile-buildpack has changed the way the nginx config file templating works. This breaks the redirect.

How to review
-------------

This was tested with the following manifest.yml in dev-05

```
---
applications:
- name: paas-tech-docs
  buildpack: staticfile_buildpack
  memory: 64M
  instances: 2
  stack: cflinuxfs3
  routes:
  - route: "docs.dev05.dev.cloudpipeline.digital"

- name: paas-tech-docs-redirect
  buildpack: nginx_buildpack
  path: redirect
  memory: 32M
  instances: 2
  stack: cflinuxfs3
  routes:
  - route: "paas-tech-docs.dev05.dev.cloudpipeline.digital"
  env:
    REDIRECT_DOMAIN: "docs.dev05.dev.cloudpipeline.digital"
```

Who can review
--------------

Any team member.
