### PR TITLE
185509385 - Configure dependabot to track GitHub actions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,8 +9,8 @@ How to review
 Describe the steps required to test the changes.
 
 1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
-1. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
-1. …
+2. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
+3. …
 
 Who can review
 --------------

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,9 @@ updates:
     interval: "daily"
   pull-request-branch-name:
     separator: "-"
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: github-action


### PR DESCRIPTION
Description:
-------------
- Dependabot will raise a PR for GitHub actions with a hash for the newer version
- Currently set to weekly to follow the current practice but this can be changed later pending an RFC

How to review
-------------
Code review

Who can review
--------------

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.
