### PR TITLE
move documentation for point-in-time restores

### DIFF
--- a/source/documentation/deploying_services/mysql.md
+++ b/source/documentation/deploying_services/mysql.md
@@ -533,6 +533,18 @@ To restore from a point in time:
     cf create-service mysql large-8.0 my-mysql-service-copy  -c '{"restore_from_point_in_time_of": "32938730-e603-44d6-810e-b4f12d7d109e"}'
     ```
 
+    By default, the database is restored to the most recent point in time checkpoint available.
+    If you need to restore to a particular point in time, you can use the `restore_from_point_in_time_before` parameter.
+
+    For example:
+
+    ```
+    cf create-service mysql large-8.0 my-mysql-service-copy  -c '{"restore_from_point_in_time_of": "32938730-e603-44d6-810e-b4f12d7d109e", "restore_from_point_in_time_before": "2020-10-27 13:00:00"}'
+    ```
+
+    will create a new database from the write-ahead logs before October 27th 2020
+    13:00 UTC.
+
  3. It takes between 5 to 10 minutes for the new service instance to be set up. To find out its status, run:
 
     ```
@@ -558,20 +570,6 @@ To restore from a point in time:
   spaces. If you need to copy data to a different organisation and/or space,
   you can [connect to your MySQL instance from a local machine using
   Conduit](/deploying_services/mysql/#connect-to-a-mysql-service-from-your-local-machine).
-
-By default, the database is restored to the most recent point in time
-checkpoint available.
-If you need to restore to a particular point in time,
-you can use the `restore_from_point_in_time_before` parameter.
-
-For example:
-
-```
-cf create-service mysql large-8.0 my-mysql-service-copy  -c '{"restore_from_point_in_time_of": "32938730-e603-44d6-810e-b4f12d7d109e", "restore_from_point_in_time_before": "2020-10-27 13:00:00"}'
-```
-
-will create a new database from the write-ahead logs before October 27th 2020
-13:00 UTC.
 
 ## Upgrading major versions of MySQL
 

--- a/source/documentation/deploying_services/postgresql.md.erb
+++ b/source/documentation/deploying_services/postgresql.md.erb
@@ -765,6 +765,18 @@ To restore from a point in time:
     cf create-service postgres large-11 my-pg-service-copy  -c '{"restore_from_point_in_time_of": "32938730-e603-44d6-810e-b4f12d7d109e"}'
     ```
 
+    By default, the database is restored to the most recent point in time checkpoint available.
+    If you need to restore to a particular point in time, you can use the `restore_from_point_in_time_before` parameter.
+
+    For example:
+
+    ```
+    cf create-service postgres large-11 my-pg-service-copy  -c '{"restore_from_point_in_time_of": "32938730-e603-44d6-810e-b4f12d7d109e", "restore_from_point_in_time_before": "2020-10-27 13:00:00"}'
+    ```
+
+    will create a new database from the write-ahead logs before October 27th 2020
+    13:00 UTC.
+
  3. It takes between 5 to 10 minutes for the new service instance to be set up. To find out its status, run:
 
     ```
@@ -790,20 +802,6 @@ To restore from a point in time:
   spaces. If you need to copy data to a different organisation and/or space,
   you can [connect to your PostgreSQL instance from a local machine using
   Conduit](/deploying_services/postgresql/#connect-to-a-postgresql-service-from-your-local-machine).
-
-By default, the database is restored to the most recent point in time
-checkpoint available.
-If you need to restore to a particular point in time,
-you can use the `restore_from_point_in_time_before` parameter.
-
-For example:
-
-```
-cf create-service postgres large-11 my-pg-service-copy  -c '{"restore_from_point_in_time_of": "32938730-e603-44d6-810e-b4f12d7d109e", "restore_from_point_in_time_before": "2020-10-27 13:00:00"}'
-```
-
-will create a new database from the write-ahead logs before October 27th 2020
-13:00 UTC.
 
 ## Upgrading major versions of Postgres
 


### PR DESCRIPTION
What
----

As per ticket 185551147, we move the documentation for database restores from a specific point-in-time snapshot to a more relevant place.

How to review
-------------

Describe the steps required to test the changes.

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that it renders as expected.
2. Manually check that any removed or renamed anchor tags are not in use ([linkchecker](https://github.com/linkcheck/linkchecker) doesn't do this).
3. …

Who can review
--------------

Anyone but @fearoffish 
