### PR TITLE
BAU - Fix issue with security.txt not displaying as HTML

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ build: ## Builds the project
 	bundle exec middleman build $(VERBOSE_FLAG)
 	@echo "Copy additional files..."
 	cp googlec7239f490e1990a5.html build
+	cp security.txt.html build
+	cp security.txt.html build/.well-known
 
 .PHONY: test
 test: test-filesystem test-local-http ## Runs the tests

--- a/config.rb
+++ b/config.rb
@@ -8,7 +8,5 @@ end
 
 GovukTechDocs.configure(self)
 
-redirect "security.txt", to: "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt"
-page "security.txt", :content_type => 'text/html'
-redirect ".well-known/security.txt", to: "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt"
-page ".well-known/security.txt", :content_type => 'text/html'
+redirect "security.txt.html", to: "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt"
+redirect ".well-known/security.txt.html", to: "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt"

--- a/security.txt.html
+++ b/security.txt.html
@@ -1,0 +1,10 @@
+              <html>
+                <head>
+                  <link rel="canonical" href="https://vdp.cabinetoffice.gov.uk/.well-known/security.txt" />
+                  <meta http-equiv=refresh content="0; url=https://vdp.cabinetoffice.gov.uk/.well-known/security.txt" />
+                  <meta name="robots" content="noindex,follow" />
+                  <meta http-equiv="cache-control" content="no-cache" />
+                </head>
+                <body>
+                </body>
+              </html>


### PR DESCRIPTION
Description:
----
- Both the `security.txt` and `.well-known/security.txt` display as `.txt` files in GitHub pages not as HTML. There isn't a known way to change the MIME type to text/html in GitHub pages so the workaround involves copying the `security.txt.html` file manually
- The redirect is added for middleman server
- The empty `.nojekyll` file is added to turn off Jekyll in GitHub pages as this causes it not to recognize directories starting with . - see [here](https://github.com/orgs/community/discussions/22227)
