### PR TITLE
BAU - Use make build step in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
           make test
 
       - name: Build middleman site
-        run: bundle exec middleman build
+        run: make build
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@a753861a5debcf57bf8b404356158c8e1e33150c


### PR DESCRIPTION
Description:
---
- Incorrectly uses `bundle exec middleman build` and not `make build`
- Change allows `googlec7239f490e1990a5.html` to be copied into the directory