### PR TITLE
[#1275640] Corrected a link in s3 Migration guidance

### DIFF
--- a/source/documentation/deploying_services/s3.md
+++ b/source/documentation/deploying_services/s3.md
@@ -255,7 +255,7 @@ The migration process has two main steps:
 
 To start this migration, you need to apply an IAM bucket policy to your AWS account. This IAM policy will let objects move from the PaaS S3 bucket to your S3 bucket. 
 
-Before creating the bucket policy, you’ll need the Amazon Resource Name (ARN) of the PaaS bucket’s owner. To get this ARN, [create a service key and get the service key credentials](#connect-to-an-s3-bucket-from-outside-of-the-govuk-paas).
+Before creating the bucket policy, you’ll need the Amazon Resource Name (ARN) of the PaaS bucket’s owner. To get this ARN, [create a service key and get the service key credentials](/deploying_services/s3/#connect-to-an-s3-bucket-from-outside-of-the-gov-uk-paas).
 
 Export the credentials as AWS environment variables or create a profile in `~/.aws/credentials` to make the PaaS user’s credentials available to the AWS CLI.
 


### PR DESCRIPTION
What
----

The recently added s3 migration guidance had a link within it that was faulty. The link is named `create a service key and get the service key credentials`. That has been corrected.

How to review
-------------

1. Preview the content locally ([see README](https://github.com/alphagov/paas-tech-docs#preview)) and check that the link named `create a service key and get the service key credentials` works as expected.

Who can review
--------------

Any paas developer..
