### PR TITLE
Rexml version update from 3.2.6 to 3.3.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redcarpet (3.5.1)
-    rexml (3.2.6)
+    rexml (3.3.6)
     rouge (3.30.0)
     sass (3.4.25)
     sassc (2.4.0)


### PR DESCRIPTION
What
----
Bump rexml from 3.2.6 to 3.3.6

Describe what you have changed and why.
version update for dependabot alert

